### PR TITLE
Add unit test for Mean and Sum

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -501,6 +501,141 @@ function cunntest.Max_backward()
 
    mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
 end
+
+function cunntest.Sum_forward()
+   local size1 = math.random(1,1000)
+   local size2 = math.random(2,100)
+
+   local tm = {}
+   local title = string.format('Sum forward %dx%d', size1, size2)
+   times[title] = tm
+
+   local input = torch.randn(size1,size2)
+   local sconv = nn.Sum(2)
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = nn.Sum(2):cuda()
+   local rescuda = gconv:forward(input)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+end
+
+function cunntest.Sum_backward()
+   local size1 = math.random(1,1000)
+   local size2 = math.random(2,100)
+
+   local tm = {}
+   local title = string.format('Sum.backward %dx%d', size1, size2)
+   times[title] = tm
+
+   local input = torch.randn(size1,size2)
+   local gradOutput = torch.randn(size1)
+   local sconv = nn.Sum(2)
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundgrad = sconv:backward(input, gradOutput)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:backward(input, gradOutput)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
+function cunntest.Mean_forward()
+   local size1 = math.random(1,1000)
+   local size2 = math.random(2,100)
+
+   local tm = {}
+   local title = string.format('Mean forward %dx%d', size1, size2)
+   times[title] = tm
+
+   local input = torch.randn(size1,size2)
+   local sconv = nn.Mean(2)
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = nn.Mean(2):cuda()
+   local rescuda = gconv:forward(input)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+end
+
+function cunntest.Mean_backward()
+   local size1 = math.random(1,1000)
+   local size2 = math.random(2,100)
+
+   local tm = {}
+   local title = string.format('Mean.backward %dx%d', size1, size2)
+   times[title] = tm
+
+   local input = torch.randn(size1,size2)
+   local gradOutput = torch.randn(size1)
+   local sconv = nn.Mean(2)
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundgrad = sconv:backward(input, gradOutput)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:backward(input, gradOutput)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
 function cunntest.SpatialConvolution_forward()
    local from = math.random(1,64)
    local to = math.random(1,64)


### PR DESCRIPTION
Add unit test for Mean and Sum, which are now CUDA-compatible thanks to torch/nn#5  by @akfidjeland. 
Note that the unit test on my machine says the GPU Mean is slower than CPU Mean, especially for `Mean.backward`:

```
Mean forward 402x28:     average speedup is 0.11979166666667
Sum forward 865x4:       average speedup is 0.62376237623762
Mean.backward 384x11:    average speedup is 0.020155748969308
Sum.backward 952x20:     average speedup is 1.8684210526316
```

Can someone try on another machine and see, please? 

I'm not too worried, though: it could be that the test size is too small. Besides, even if there indeed is a slow-down, having a CUDA Mean/Sum is useful when part of a larger cuda'd module, to avoid host/device trnasfers.
