### PR TITLE
Fix compiler warnings in SpatialConvolutionCUDA.cu

### DIFF
--- a/SpatialConvolutionCUDA.cu
+++ b/SpatialConvolutionCUDA.cu
@@ -44,7 +44,7 @@ static int cunn_SpatialConvolutionCUDA_updateOutput(lua_State *L)
   
   // asserts
   luaL_argcheck(L, inputWidth == inputHeight, 1, "input must be square");
-  luaL_argcheck(L, kW == kW, 1, "kH must be equal to kW");
+  luaL_argcheck(L, kH == kW, 1, "kH must be equal to kW");
   luaL_argcheck(L, dH == dW, 1, "dH must be equal to dW");
 
   // all the data must be contiguous: 
@@ -96,7 +96,7 @@ static int cunn_SpatialConvolutionCUDA_updateGradInput(lua_State *L)
   
   // asserts
   luaL_argcheck(L, inputWidth == inputHeight, 1, "input must be square");
-  luaL_argcheck(L, kW == kW, 1, "kH must be equal to kW");
+  luaL_argcheck(L, kH == kW, 1, "kH must be equal to kW");
   luaL_argcheck(L, dH == dW, 1, "dH must be equal to dW");
 
   // all the data must be contiguous: 
@@ -146,7 +146,7 @@ static int cunn_SpatialConvolutionCUDA_accGradParameters(lua_State *L)
   
   // asserts
   luaL_argcheck(L, inputWidth == inputHeight, 1, "input must be square");
-  luaL_argcheck(L, kW == kW, 1, "kH must be equal to kW");
+  luaL_argcheck(L, kH == kW, 1, "kH must be equal to kW");
   luaL_argcheck(L, dH == dW, 1, "dH must be equal to dW");
 
   if (partialSum) {

--- a/SpatialConvolutionCUDA/updateGradInput.cu
+++ b/SpatialConvolutionCUDA/updateGradInput.cu
@@ -525,7 +525,6 @@ void spatialConv_updateGradInput(
 {
     int numGroups = 1;
     int numFilterColors = numImgColors / numGroups;
-    int numModules = numModulesY * numModulesX;
     /* int filterModuleMult = conv ? 1 : numModules; */
     int filterSize = filterSizeX;
     int imgPixels = imgSizeY * imgSizeX;


### PR DESCRIPTION
Just some minor cleanups.

```
Running 38 tests
______________________________________  ==> Done Completed 56 asserts in 38 tests with 0 errors
--------------------------------------------------------------------------------

SpatialMaxPooling.forward 9x32x362x332 o 2x4 -> 9x32x181x83:     average speedup is 4.7224495937406
SoftMax forward 37 -> 37:        average speedup is 0.17469879518072
LogSoftMax.backward 39 -> 39:    average speedup is 0.12274368231047
SpatialSubSampling.forward 7x42x258x106 o 2x4 -> 7x42x65x35:     average speedup is 0.8765923566879
Tanh.backward 56 -> 56:          average speedup is 0.14529914529915
SpatialConvolution.forward 12x5x35x51 o 15x5 -> 12x21x11x47 [s: 2x1]:    average speedup is 0.16042928627864
Tanh forward 6 -> 6:     average speedup is 0.0063067608476287
Sigmoid forward 45 -> 45:        average speedup is 0.030266343825666
Threshold forward 97 -> 97:      average speedup is 0.38532110091743
Sqrt forward 10 -> 10:   average speedup is 0.04113475177305
SpatialLPPooling.backward (P=2 only) 9x102x86 o 2x2 -> 9x51x43:          average speedup is 2.0689655172414
SpatialConvolution.backward 32x8x15x15 o 7x7 -> 32x32x5x5:       average speedup is 8.6660210293304
Sigmoid.backward 30 -> 30:       average speedup is 0.2
Threshold.backward 66 -> 66:     average speedup is 0.036755386565272
Max.backward 620x98:     average speedup is 0.12307692307692
Sqrt.backward 94 -> 94:          average speedup is 0.304
SpatialMaxPooling.backward 6x38x138x100 o 3x2 -> 6x38x46x50:     average speedup is 0.88458819370802
LogSoftMax forward 26 -> 26:     average speedup is 0.0625
SpatialConvolution.forward 3x290x135 o 4x14 -> 57x144x122 [s: 2x1]:      average speedup is 0.27754361471604
SpatialConvolution.backward 23x137x57 o 13x12 -> 27x125x46:      average speedup is 0.13236147438238
SoftMax.backward 7 -> 7:         average speedup is 0.11261261261261
Square.backward 88 -> 88:        average speedup is 0.34862385321101
MSECriterion 3410 :      average speedup is 0.059097978227061
SpatialLPPooling.forward (P=2 only) 23x672x244 o 4x2 -> 23x168x122:      average speedup is 9.208041958042
SpatialConvolutionCUDA.forward 32x8x70x70 o 8x8 -> 32x32x63x63 [s: 1x1]:         average speedup is 11.186765313119
SpatialSubSampling.forward 11x718x456 o 4x4 -> 11x239x227:       average speedup is 2.2360584395399
SpatialMaxPooling.forward 51x354x444 o 2x2 -> 51x177x222:        average speedup is 7.6214793485108
SpatialMaxPooling.backward 9x164x66 o 4x2 -> 9x41x33:    average speedup is 0.47185430463576
SpatialSubSampling.backward 5x34x126x118 o 2x2 -> 5x34x63x59:    average speedup is 1.2965170223396
Abs forward 80 -> 80:    average speedup is 0.0336
SpatialConvolution.backward 8x1x58x54 o 13x8 -> 8x55x46x47:      average speedup is 0.13817821618874
Abs.backward 18 -> 18:   average speedup is 0.32608695652174
SpatialMaxPoolingCUDA.backward 32x16x124x124 o 4x4 -> 32x16x31x31:       average speedup is 0.47886466426998
SpatialSubSampling.backward 12x183x168 o 3x4 -> 12x61x42:        average speedup is 0.3054620405359
MSECriterion2 3410 :     average speedup is 0.25850340136054
SpatialMaxPoolingCUDA.forward 32x32x96x96 o 3x3 -> 32x32x32x32:          average speedup is 12.043622569938
Square forward 66 -> 66:         average speedup is 0.10596026490066
Max forward 321x54:      average speedup is 0.30489731437599
```
