### PR TITLE
added a max call for SM 2.0 restrictions.

### DIFF
--- a/SpatialUpSamplingNearest.cu
+++ b/SpatialUpSamplingNearest.cu
@@ -91,7 +91,10 @@ static int cunn_SpatialUpSamplingNearest_updateOutput(lua_State *L)
 
   // cuda blocks & threads:
   long nthreads = 256;
-  long nblocks = ceil((float)no_elements / nthreads);
+  // Max number of blocks: http://en.wikipedia.org/wiki/CUDA
+  // 65535 for SM 2.x, 2^32 -1 for >= 3.0
+  // TODO: When we move to SM 3.5 we should update this
+  long nblocks = min(max((int)ceil((float)no_elements / nthreads), 1), 65535);
   dim3 blocks(nblocks);
   dim3 threads(nthreads);
 


### PR DESCRIPTION
We have been using SM 3.5 as our CUDA compile target.  As such, we had no problem allocating a massive block size:

http://en.wikipedia.org/wiki/CUDA

Technical specifications    Compute capability (version)
Maximum x-, y-, or z-dimension of a grid of thread blocks   65535 <= 2.x,   2^31-1 >= 3.0

It seems the new cunn is still stuck on 2.0.  Is there a reason why we haven't updated the target yet?  I assume it is for backwards compatibility, but I wonder if it isn't time to modify CMake with the updated cuda target.

In any case, this pull request fixes SpatialUpSamplingNearest when large inputs are used (the unit test didn't catch this case).
