### PR TITLE
Pointwise layers use apply kernels

### DIFF
--- a/Exp.cu
+++ b/Exp.cu
@@ -2,9 +2,9 @@
 
 struct expupdateOutput_functor
 {
-  __host__ __device__ float operator()(const float& input) const
+  __device__ void operator()(float* output, const float* input) const
   {
-    return exp(input);
+    *output = exp(*input);
   }
 };
 
@@ -13,25 +13,17 @@ static int cunn_Exp_updateOutput(lua_State *L)
   THCState *state = getCutorchState(L);
   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
-  long size = THCudaTensor_nElement(state, input);
-
-  input = THCudaTensor_newContiguous(state, input);
 
   THCudaTensor_resizeAs(state, output, input);
-
-  thrust::device_ptr<float> output_data(THCudaTensor_data(state, output));
-  thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
-  thrust::transform(input_data, input_data+size, output_data, expupdateOutput_functor());
-
-  THCudaTensor_free(state, input);
+  THCudaTensor_pointwiseApply2(state, output, input, expupdateOutput_functor());
   return 1;
 }
 
 struct expupdateGradInput_functor
 {
-  __host__ __device__ float operator()(const float& output, const float& gradOutput) const
+  __device__ void operator()(float* gradInput, const float* output, const float* gradOutput) const
   {
-    return gradOutput * output;
+    *gradInput = *gradOutput * *output;
   }
 };
 
@@ -41,18 +33,9 @@ static int cunn_Exp_updateGradInput(lua_State *L)
   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
   THCudaTensor *gradOutput = (THCudaTensor*)luaT_checkudata(L, 3, "torch.CudaTensor");
   THCudaTensor *gradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradInput", "torch.CudaTensor");
-  long size = THCudaTensor_nElement(state, output);
-
-  gradOutput = THCudaTensor_newContiguous(state, gradOutput);
 
   THCudaTensor_resizeAs(state, gradInput, output);
-
-  thrust::device_ptr<float> output_data(THCudaTensor_data(state, output));
-  thrust::device_ptr<float> gradOutput_data(THCudaTensor_data(state, gradOutput));
-  thrust::device_ptr<float> gradInput_data(THCudaTensor_data(state, gradInput));
-  thrust::transform(output_data, output_data+size, gradOutput_data, gradInput_data, expupdateGradInput_functor());
-
-  THCudaTensor_free(state, gradOutput);
+  THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, expupdateGradInput_functor());
   return 1;
 }
 

--- a/LogSigmoid.cu
+++ b/LogSigmoid.cu
@@ -38,7 +38,6 @@ static int cunn_LogSigmoid_updateGradInput(lua_State *L)
 
   THCudaTensor_resizeAs(state, gradInput, input);
   THCudaTensor_pointwiseApply3(state, gradInput, input, gradOutput, logSigmoid_updateGradInput_functor());
-  THCudaTensor_free(state, gradOutput);
   return 1;
 }
 

--- a/Sigmoid.cu
+++ b/Sigmoid.cu
@@ -2,9 +2,9 @@
 
 struct sigmoidupdateOutput_functor
 {
-  __host__ __device__ float operator()(const float& input) const
+  __device__ void operator()(float* output, const float* input) const
   {
-    return 1./(1.+ exp(-input));
+    *output = 1./(1.+ exp(-*input));
   }
 };
 
@@ -13,25 +13,17 @@ static int cunn_Sigmoid_updateOutput(lua_State *L)
   THCState *state = getCutorchState(L);
   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
-  long size = THCudaTensor_nElement(state, input);
-
-  input = THCudaTensor_newContiguous(state, input);
 
   THCudaTensor_resizeAs(state, output, input);
-
-  thrust::device_ptr<float> output_data(THCudaTensor_data(state, output));
-  thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
-  thrust::transform(input_data, input_data+size, output_data, sigmoidupdateOutput_functor());
-
-  THCudaTensor_free(state, input);
+  THCudaTensor_pointwiseApply2(state, output, input, sigmoidupdateOutput_functor());
   return 1;
 }
 
 struct sigmoidupdateGradInput_functor
 {
-  __host__ __device__ float operator()(const float& output, const float& gradOutput) const
+  __device__ void operator()(float* gradInput, const float* output, const float* gradOutput) const
   {
-    return gradOutput * (1.-output) * output;
+    *gradInput = *gradOutput * (1.-*output) * *output;
   }
 };
 
@@ -41,18 +33,9 @@ static int cunn_Sigmoid_updateGradInput(lua_State *L)
   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
   THCudaTensor *gradOutput = (THCudaTensor*)luaT_checkudata(L, 3, "torch.CudaTensor");
   THCudaTensor *gradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradInput", "torch.CudaTensor");
-  long size = THCudaTensor_nElement(state, output);
-
-  gradOutput = THCudaTensor_newContiguous(state, gradOutput);
 
   THCudaTensor_resizeAs(state, gradInput, output);
-
-  thrust::device_ptr<float> output_data(THCudaTensor_data(state, output));
-  thrust::device_ptr<float> gradOutput_data(THCudaTensor_data(state, gradOutput));
-  thrust::device_ptr<float> gradInput_data(THCudaTensor_data(state, gradInput));
-  thrust::transform(output_data, output_data+size, gradOutput_data, gradInput_data, sigmoidupdateGradInput_functor());
-
-  THCudaTensor_free(state, gradOutput);
+  THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, sigmoidupdateGradInput_functor());
   return 1;
 }
 

--- a/Tanh.cu
+++ b/Tanh.cu
@@ -2,9 +2,9 @@
 
 struct tanhupdateOutput_functor
 {
-  __host__ __device__ float operator()(const float& input) const
+  __device__ void operator()(float* output, const float* input) const
   {
-    return tanh(input);
+    *output = tanh(*input);
   }
 };
 
@@ -13,25 +13,17 @@ static int cunn_Tanh_updateOutput(lua_State *L)
   THCState *state = getCutorchState(L);
   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
-  long size = THCudaTensor_nElement(state, input);
-
-  input = THCudaTensor_newContiguous(state, input);
 
   THCudaTensor_resizeAs(state, output, input);
-
-  thrust::device_ptr<float> output_data(THCudaTensor_data(state, output));
-  thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
-  thrust::transform(input_data, input_data+size, output_data, tanhupdateOutput_functor());
-
-  THCudaTensor_free(state, input);
+  THCudaTensor_pointwiseApply2(state, output, input, tanhupdateOutput_functor());
   return 1;
 }
 
 struct tanhupdateGradInput_functor
 {
-  __host__ __device__ float operator()(const float& output, const float& gradOutput) const
+  __device__ void operator()(float* gradInput, const float* output, const float* gradOutput) const
   {
-    return gradOutput * (1-output*output);
+    *gradInput = *gradOutput * (1 - *output * *output);
   }
 };
 
@@ -41,18 +33,9 @@ static int cunn_Tanh_updateGradInput(lua_State *L)
   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
   THCudaTensor *gradOutput = (THCudaTensor*)luaT_checkudata(L, 3, "torch.CudaTensor");
   THCudaTensor *gradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradInput", "torch.CudaTensor");
-  long size = THCudaTensor_nElement(state, output);
-
-  gradOutput = THCudaTensor_newContiguous(state, gradOutput);
 
   THCudaTensor_resizeAs(state, gradInput, output);
-
-  thrust::device_ptr<float> output_data(THCudaTensor_data(state, output));
-  thrust::device_ptr<float> gradOutput_data(THCudaTensor_data(state, gradOutput));
-  thrust::device_ptr<float> gradInput_data(THCudaTensor_data(state, gradInput));
-  thrust::transform(output_data, output_data+size, gradOutput_data, gradInput_data, tanhupdateGradInput_functor());
-
-  THCudaTensor_free(state, gradOutput);
+  THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, tanhupdateGradInput_functor());
   return 1;
 }
 


### PR DESCRIPTION
Uses apply kernels instead of thrust, so all newContiguous() calls are removed.
It seems to me that there could be written a general Pointwise module (as in  cudnn) to which only forward and backward functors would be given, instead of copy-pasting.
Compile time increased.
Includes Sqrt.cu fix from https://github.com/torch/cunn/pull/76