### PR TITLE
Add TransferDevice module.

### DIFF
--- a/TransferGPU.lua
+++ b/TransferGPU.lua
@@ -1,0 +1,36 @@
+local TransferGPU, parent = torch.class('nn.TransferGPU', 'nn.Module')
+
+function TransferGPU:__init(srcDev, dstDev)
+   parent.__init(self)
+
+   self.srcDev = srcDev
+   self.dstDev = dstDev
+
+   self.gradInput = torch.CudaTensorOn(srcDev)
+   self.output    = torch.CudaTensorOn(dstDev)
+
+end
+
+function TransferGPU:updateOutput(input)
+   assert(input:getDevice() == self.srcDev, 
+      string.format("input on wrong device, expected %d got %d", input:getDevice(), self.srcDev))
+   if self.srcDev ~= self.dstDev then
+      self.output:resize(input:size()):copy(input)
+   else
+      self.output = input
+   end
+   return self.output
+end
+
+function TransferGPU:updateGradInput(input, gradOutput)
+   assert(input:getDevice() == self.srcDev, 
+      string.format("input on wrong device, expected %d got %d", input:getDevice(), self.srcDev))
+   assert(gradOutput:getDevice() == self.dstDev,
+      string.format("gradOutput on wrong device, expected %d got %d", gradOutput:getDevice(), self.dstDev))
+   if self.srcDev ~= self.dstDev then
+      self.gradInput:resize(gradOutput:size()):copy(gradOutput)
+   else
+      self.gradInput = gradOutput
+   end
+   return self.gradInput
+end

--- a/init.lua
+++ b/init.lua
@@ -3,5 +3,15 @@ require "nn"
 require "libcunn"
 
 include('test.lua')
+include('utils.lua')
 
 include('DataParallelTable.lua')
+include('TransferGPU.lua')
+
+function nn.Module:cudaOn(device)
+  return nn.utils.recursiveCudaOn(self, device)
+end
+
+function nn.Criterion:cudaOn(device)
+  return nn.utils.recursiveCudaOn(self, device)
+end

--- a/utils.lua
+++ b/utils.lua
@@ -1,0 +1,12 @@
+function nn.utils.recursiveCudaOn(param, device)
+   if torch.type(param) == 'table' or
+      torch.isTypeOf(param, 'nn.Module') or
+      torch.isTypeOf(param, 'nn.Criterion') then
+      for k, v in pairs(param) do
+         param[k] = nn.utils.recursiveCudaOn(v, device)
+      end
+   elseif torch.isTensor(param) then
+      param = param:cudaOn(device)
+   end
+   return param
+end


### PR DESCRIPTION
With cutorch auto-mode, multi-gpu models can be run without explicitly
updating the device. However, copies must be explicit, so a
TransferDevice module is necessary to make the copy.

Here's an example multi-GPU module (added as a test):

```lua
cutorch.setDevice(0)

net = nn.Sequential()
for i = 1,3 do
  net:add(nn.Linear(1000,1000):cuda(i))
  net:add(nn.SoftMax():cuda(i))
  net:add(nn.TransferDevice(i, i+1)) -- a new little shim in cunn
end

local input = torch.CudaTensorOn(1, 1000)
local output = net:forward(input)
print(output:getDevice())

local gradOutput = output/100
local gradInput = net:backward(input, gradOutput)
print(gradInput:getDevice())
```