### PR TITLE
DataParallelTable cleanup/refactoring.

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -1,506 +1,516 @@
-local gpu_local_copy_buffers = {}
-local base_gpu_index = 1  -- A constant
+local gpuLocalCopyBuffers = {}
+local baseGpuIndex = 1  -- A constant
 
 -- *****************************************************************************
 -- Helper Functions
 -- *****************************************************************************
--- queryGPUDeviceId - Function to query a tensor or table for the 
--- GPUID.  For tables we will search the table for CudaTensors, query their 
+-- queryGPUDeviceId - Function to query a tensor or table for the
+-- GPUID.  For tables we will search the table for CudaTensors, query their
 -- device and make sure the deviceIds of ALL CudaTensors are on the same GPU.
 local function queryGPUDeviceId(object)
-  if torch.type(object) == 'torch.CudaTensor' then
-    return object:getDevice()
-  end
+   if torch.type(object) == 'torch.CudaTensor' then
+      return object:getDevice()
+   end
 
-  local deviceId
+   local deviceId
 
-  -- Try finding a parameter
-  local stack = {}  -- explicit stack to recurse on tables
-  for key, param in pairs(object) do
-    if key ~= 'modules' then
-      stack[#stack+1] = param  -- Push onto the stack
-    end
-  end
-  while #stack > 0 do
-    local param = stack[#stack]; stack[#stack] = nil  -- Pop the stack
-    if (torch.type(param) == 'table') then
-      for i = 1, #param do stack[#stack+1] = param[i] end  -- Push onto stack
-    elseif (torch.type(param) == 'torch.CudaTensor') then
-      if (torch.numel(param) > 0) then
-        -- Empty tensors are always on GPU "0"
-        local cur_id = param:getDevice()
-        if deviceId == nil then
-          deviceId = cur_id
-        else
-          assert(deviceId == cur_id, 
-            'Found CudaTensor instances from different devices')
-        end
+   -- Try finding a parameter
+   local stack = {}  -- explicit stack to recurse on tables
+   for key, param in pairs(object) do
+      if key ~= 'modules' then
+         stack[#stack+1] = param  -- Push onto the stack
       end
-    end
-  end
+   end
+   while #stack > 0 do
+      local param = stack[#stack]; stack[#stack] = nil  -- Pop the stack
+      if (torch.type(param) == 'table') then
+         for i = 1, #param do stack[#stack+1] = param[i] end  -- Push onto stack
+      elseif (torch.type(param) == 'torch.CudaTensor') then
+         if (torch.numel(param) > 0) then
+            -- Empty tensors are always on GPU "0"
+            local curId = param:getDevice()
+            if deviceId == nil then
+               deviceId = curId
+            else
+               assert(deviceId == curId,
+               'Found CudaTensor instances from different devices')
+            end
+         end
+      end
+   end
 
-  return deviceId
+   return deviceId
 end
 
 -- Get an avaliable GPU buffer for asyncGPUCopy.  It is used when the GPU tensor
 -- is not contiguous.
 local function getBuffer()
-  local device = cutorch.getDevice()
-  if not gpu_local_copy_buffers[device] then
-    gpu_local_copy_buffers[device] = torch.CudaTensor()
-  end
-  return gpu_local_copy_buffers[device]
+   local device = cutorch.getDevice()
+   if not gpuLocalCopyBuffers[device] then
+      gpuLocalCopyBuffers[device] = torch.CudaTensor()
+   end
+   return gpuLocalCopyBuffers[device]
 end
 
 -- setDeviceSafe - Avoid redundant calls to setDevice
 local function setDevice(gpuid)
-  if (cutorch.getDevice() ~= gpuid) then
-    cutorch.setDevice(gpuid)
-  end
+   if (cutorch.getDevice() ~= gpuid) then
+      cutorch.setDevice(gpuid)
+   end
 end
 
 -- Asynchronous copy from source to dest from GPU to GPU.
 -- This is borrowed (with modifications) from fbcunn.
 local function asyncGPUCopy(dest, source)
-  assert(torch.typename(dest) == 'torch.CudaTensor')
-  assert(torch.typename(source) == 'torch.CudaTensor')
-  local prev_device = cutorch.getDevice()
-  
-  local dest_gpuid = dest:getDevice()
-  local source_gpuid = source:getDevice()
-  
-  if source_gpuid == dest_gpuid then
-    -- if both tensors are on the same gpu normal operation works
-    setDevice(dest_gpuid)
-    dest:copy(source)
-    setDevice(prev_device)
-    return
-  end
-  
-  if source:isContiguous() and dest:isContiguous() then
-    -- if both tensors are contiguous operation across gpus works
-    setDevice(dest_gpuid)
-    dest:copy(source)
-    setDevice(prev_device)
-    return
-  end
+   assert(torch.typename(dest) == 'torch.CudaTensor')
+   assert(torch.typename(source) == 'torch.CudaTensor')
+   local prevDevice = cutorch.getDevice()
 
-  -- Either the dest or the source are not contiguous.  we will need to do
-  -- intermediate copies.
-  local tmp_source = source
-  if not source:isContiguous() then
-    setDevice(source_gpuid)
-    tmp_source = getBuffer()
-    tmp_source:resizeAs(source)
-    tmp_source:copy(source)  -- Make contiguous using a copy
-  end
+   local destGpuid = dest:getDevice()
+   local sourceGpuid = source:getDevice()
 
-  setDevice(dest_gpuid)
-  local tmp_dest = dest
-  if not dest:isContiguous() then
-    local tmp_dest = getBuffer()
-    tmp_dest:resizeAs(tmp_source)
-    tmp_dest:copy(tmp_source)
-  end
-  
-  dest:copy(tmp_dest)
-  
-  cutorch.synchronize()  -- Ensures we keep the buffer for the copy duration
-  
-  -- Put the device back to what it was.
-  setDevice(prev_device)
+   if sourceGpuid == destGpuid then
+      -- if both tensors are on the same gpu normal operation works
+      setDevice(destGpuid)
+      dest:copy(source)
+      setDevice(prevDevice)
+      return
+   end
+
+   if source:isContiguous() and dest:isContiguous() then
+      -- if both tensors are contiguous operation across gpus works
+      setDevice(destGpuid)
+      dest:copy(source)
+      setDevice(prevDevice)
+      return
+   end
+
+   -- Either the dest or the source are not contiguous.  we will need to do
+   -- intermediate copies.
+   local tmpSource = source
+   if not source:isContiguous() then
+      setDevice(sourceGpuid)
+      tmpSource = getBuffer()
+      tmpSource:resizeAs(source)
+      tmpSource:copy(source)  -- Make contiguous using a copy
+   end
+
+   setDevice(destGpuid)
+   local tmpDest = dest
+   if not dest:isContiguous() then
+      local tmpDest = getBuffer()
+      tmpDest:resizeAs(tmpSource)
+      tmpDest:copy(tmpSource)
+   end
+
+   dest:copy(tmpDest)
+
+   cutorch.synchronize()  -- Ensures we keep the buffer for the copy duration
+
+   -- Put the device back to what it was.
+   setDevice(prevDevice)
 end
 
-local function equalSize(size_table1, size_table2)
-  if (#size_table1 ~= #size_table2) then
-    return false
-  end
-  for i = 1, #size_table1 do
-    if size_table1[i] ~= size_table2[i] then return false end
-  end
-  return true
+local function equalSize(sizeTable1, sizeTable2)
+   if (#sizeTable1 ~= #sizeTable2) then
+      return false
+   end
+   for i = 1, #sizeTable1 do
+      if sizeTable1[i] ~= sizeTable2[i] then return false end
+   end
+   return true
 end
 
--- deepTensorsCopy - perform an elementwise copy of the tensors in the nested 
--- table. We assume that the tables are properly initialized (ie same size and 
+-- deepTensorsCopy - perform an elementwise copy of the tensors in the nested
+-- table. We assume that the tables are properly initialized (ie same size and
 -- structure), although we will assert it.
 local function deepTensorsCopy(dst, src)
-  if (torch.type(src) == 'table') then
-    assert(torch.type(dst) == 'table' and #src == #dst)
-    for i = 1, #src do deepTensorsCopy(dst[i], src[i]) end
-  elseif torch.type(src):find('torch%..+Tensor') then
-    assert(torch.type(dst):find('torch%..+Tensor'))
-    assert(dst:isSameSizeAs(src))
-    asyncGPUCopy(dst, src)
-  else
-    error('input must be a nested table of tensors!')
-  end 
+   if (torch.type(src) == 'table') then
+      assert(torch.type(dst) == 'table' and #src == #dst)
+      for i = 1, #src do deepTensorsCopy(dst[i], src[i]) end
+   elseif torch.type(src):find('torch%..+Tensor') then
+      assert(torch.type(dst):find('torch%..+Tensor'))
+      assert(dst:isSameSizeAs(src))
+      asyncGPUCopy(dst, src)
+   else
+      error('input must be a nested table of tensors!')
+   end
 end
 
--- deepTensorsAdd - perform an elementwise add of the tensors in the nested 
--- table. We assume that the tables are properly initialized (ie same size and 
+-- deepTensorsAdd - perform an elementwise add of the tensors in the nested
+-- table. We assume that the tables are properly initialized (ie same size and
 -- structure), although we will assert it.
 --
 -- Note: this is necessary because add() will malloc new memory on the cuda
 -- driver side every time we want to get new memory!  Therefore, we actually
 -- need to copy src to the dst gpu
 local function deepTensorsAdd(dst, src)
-  if (torch.type(src) == 'table') then
-    assert(torch.type(dst) == 'table' and #src == #dst)
-    for i = 1, #src do deepTensorsAdd(dst[i], src[i]) end
-  elseif torch.type(src):find('torch%..+Tensor') then
-    assert(torch.type(dst):find('torch%..+Tensor'))
-    assert(dst:isSameSizeAs(src))
-    
-    local dst_gpuid = dst:getDevice()
-    local src_gpuid = src:getDevice()
-    local cur_gpuid = cutorch:getDevice()
-    setDevice(dst_gpuid)
-    
-    -- Copy src over to a buffer on the dst GPU
-    local src_buffer_on_dst_gpu = src
-    if (dst_gpuid ~= src_gpuid) then
-      src_buffer_on_dst_gpu = getBuffer()
-      src_buffer_on_dst_gpu:resizeAs(src)
-      assert(src:isContiguous())
-      src_buffer_on_dst_gpu:copy(src)
-    end
-    
-    -- Perform the actual add
-    dst:add(src_buffer_on_dst_gpu)
-    if (dst_gpuid ~= src_gpuid) then
-      -- Ensures we get to keep the buffer for the duration of the add
-      cutorch.synchronize()
-    end
-    
-    setDevice(cur_gpuid)  -- Put the GPU id back to what it was
-  else
-    error('input must be a nested table of tensors!')
-  end 
+   if (torch.type(src) == 'table') then
+      assert(torch.type(dst) == 'table' and #src == #dst)
+      for i = 1, #src do deepTensorsAdd(dst[i], src[i]) end
+   elseif torch.type(src):find('torch%..+Tensor') then
+      assert(torch.type(dst):find('torch%..+Tensor'))
+      assert(dst:isSameSizeAs(src))
+
+      local dstGpuid = dst:getDevice()
+      local srcGpuid = src:getDevice()
+      local curGpuid = cutorch:getDevice()
+      setDevice(dstGpuid)
+
+      -- Copy src over to a buffer on the dst GPU
+      local srcBufferOnDstGpu = src
+      if (dstGpuid ~= srcGpuid) then
+         srcBufferOnDstGpu = getBuffer()
+         srcBufferOnDstGpu:resizeAs(src)
+         assert(src:isContiguous())
+         srcBufferOnDstGpu:copy(src)
+      end
+
+      -- Perform the actual add
+      dst:add(srcBufferOnDstGpu)
+      if (dstGpuid ~= srcGpuid) then
+         -- Ensures we get to keep the buffer for the duration of the add
+         cutorch.synchronize()
+      end
+
+      setDevice(curGpuid)  -- Put the GPU id back to what it was
+   else
+      error('input must be a nested table of tensors!')
+   end
 end
 
 -- *****************************************************************************
 -- DataParallelTable
 -- *****************************************************************************
-local DataParallelTable, parent = torch.class('nn.DataParallelTable', 
-  'nn.Container')
+local DataParallelTable, parent = torch.class('nn.DataParallelTable',
+'nn.Container')
 
 function DataParallelTable:__init(dimension)
-  parent.__init(self)
-  if not dimension then
-    error "must specify a dimension!"
-  end
+   parent.__init(self)
+   if not dimension then
+      error "must specify a dimension!"
+   end
 
-  self.dimension = dimension
-  self.modules = {}
-  self.gpu_assignments = {}  -- Which gpuid each module sits on
-  self.input_gpu = {}  -- inputs for each gpu
-  self.gradOutput_gpu = {} -- gradOutputs for each gpu
-  self.output_gpu = {} -- outputs for each gpu
-  self.gradInput_gpu = {} -- gradInput for each gpu
+   self.dimension = dimension
+   self.modules = {}
+   self.gpuAssignments = {}  -- Which gpuid each module sits on
+   self.inputGpu = {}  -- inputs for each gpu
+   self.gradOutputGpu = {} -- gradOutputs for each gpu
+   self.outputGpu = {} -- outputs for each gpu
+   self.gradInputGpu = {} -- gradInput for each gpu
 end
 
--- NOTE: The input should be on the FIRST added GPU device, and similarly the 
+-- NOTE: The input should be on the FIRST added GPU device, and similarly the
 -- output will be on the FIRST GPU device.
 function DataParallelTable:add(module, gpuid)
-  assert(gpuid <= cutorch.getDeviceCount() and gpuid >= 1)
-  assert(#self.modules == #self.gpu_assignments)
+   assert(gpuid <= cutorch.getDeviceCount() and gpuid >= 1)
+   assert(#self.modules == #self.gpuAssignments)
 
-  self.modules[#self.modules + 1] = module
-  self.gpu_assignments[#self.gpu_assignments + 1] = gpuid
+   self.modules[#self.modules + 1] = module
+   self.gpuAssignments[#self.gpuAssignments + 1] = gpuid
 
-  return self
+   return self
+end
+
+function DataParallelTable:__tostring()
+   return 'DataParallelTable: ' .. #self.modules .. ' x ' .. tostring(self.modules[1])
 end
 
 function DataParallelTable:get(index)
-  return self.modules[index]
+   return self.modules[index]
 end
 
 function DataParallelTable:updateOutput(input)
-  local base_gpuid = self.gpu_assignments[base_gpu_index]
-  assert(queryGPUDeviceId(input) == base_gpuid, 'Input is not on gpu ' ..
-    base_gpuid)
+   local baseGpuid = self.gpuAssignments[baseGpuIndex]
+   assert(queryGPUDeviceId(input) == baseGpuid, 'Input is not on gpu ' ..
+   baseGpuid)
 
-  local prev_gpuid = cutorch.getDevice()
+   local prevGpuid = cutorch.getDevice()
 
-  -- distribute the input to GPUs
-  for i = 1, #self.modules do
-    local gpuid = self.gpu_assignments[i]
-    -- Split the tensors in the input nested table to the GPU with gpuid
-    -- _distributeTensorRecursive(src,dst,src_gpuid,src_ind,dst_gpuid,dst_ind)
-    self.input_gpu[gpuid] = self:_distributeTensorRecursive(input, 
-      self.input_gpu[gpuid], base_gpuid, base_gpu_index, gpuid, i)  
-  end
-  
-  cutorch.synchronize()
+   -- distribute the input to GPUs
+   for i = 1, #self.modules do
+      local gpuid = self.gpuAssignments[i]
+      -- Split the tensors in the input nested table to the GPU with gpuid
+      -- _distributeTensorRecursive(src,dst,srcGpuid,srcInd,dstGpuid,dstInd)
+      self.inputGpu[gpuid] = self:_distributeTensorRecursive(
+         input, self.inputGpu[gpuid],
+         baseGpuid, baseGpuIndex, gpuid, i,
+         #self.modules
+      )
+   end
 
-  -- update output for each module asynchronously
-  for i, module in ipairs(self.modules) do   
-    local gpuid = self.gpu_assignments[i]
-    setDevice(gpuid)
-    self.output_gpu[gpuid] = module:updateOutput(self.input_gpu[gpuid])
-  end
-  
-  cutorch.synchronize()
+   cutorch.synchronize()
 
-  -- concatenate the outputs to the base GPU
-  for i = 1, #self.modules do
-    local gpuid = self.gpu_assignments[i]
-    -- Merge the tensors in the input nested table to the GPU with gpuid
-    -- _ConcatTensorRecursive(src,dst,src_gpuid,src_ind,dst_gpuid,dst_ind)
-    self.output = self:_ConcatTensorRecursive(self.output_gpu[gpuid], 
-      self.output, gpuid, i, base_gpuid, base_gpu_index)
-  end
+   -- update output for each module asynchronously
+   for i, module in ipairs(self.modules) do
+      local gpuid = self.gpuAssignments[i]
+      setDevice(gpuid)
+      self.outputGpu[gpuid] = module:updateOutput(self.inputGpu[gpuid])
+   end
 
-  setDevice(prev_gpuid)
+   cutorch.synchronize()
 
-  return self.output
+   -- concatenate the outputs to the base GPU
+   for i = 1, #self.modules do
+      local gpuid = self.gpuAssignments[i]
+      -- Merge the tensors in the input nested table to the GPU with gpuid
+      -- _concatTensorRecursive(src,dst,srcGpuid,srcInd,dstGpuid,dstInd)
+      self.output = self:_concatTensorRecursive(
+         self.outputGpu[gpuid], self.output,
+         gpuid, i, baseGpuid, baseGpuIndex,
+         #self.modules
+      )
+   end
+
+   setDevice(prevGpuid)
+
+   return self.output
 end
 
 function DataParallelTable:updateGradInput(input, gradOutput)
-  -- We assume that updateOutput has already been called (therefore input_gpu
-  -- has been populated)
-  local base_gpuid = self.gpu_assignments[base_gpu_index]
-  assert(queryGPUDeviceId(gradOutput) == base_gpuid, 
-    'gradOutput is not on gpu ' .. base_gpuid)
+   -- We assume that updateOutput has already been called (therefore inputGpu
+   -- has been populated)
+   local baseGpuid = self.gpuAssignments[baseGpuIndex]
+   assert(queryGPUDeviceId(gradOutput) == baseGpuid,
+   'gradOutput is not on gpu ' .. baseGpuid)
 
-  local prev_gpuid = cutorch.getDevice()
+   local prevGpuid = cutorch.getDevice()
 
-  -- distribute the gradOutput to GPUs
-  for i = 1, #self.modules do
-    local gpuid = self.gpu_assignments[i]
-    -- Split the tensors in the input nested table to the GPU with gpuid
-    -- _distributeTensorRecursive(src,dst,src_gpuid,src_ind,dst_gpuid,dst_ind)
-    self.gradOutput_gpu[gpuid] = self:_distributeTensorRecursive(gradOutput, 
-      self.gradOutput_gpu[gpuid], base_gpuid, base_gpu_index, gpuid, i)
-  end
-  
-  cutorch.synchronize()
+   -- distribute the gradOutput to GPUs
+   for i = 1, #self.modules do
+      local gpuid = self.gpuAssignments[i]
+      -- Split the tensors in the input nested table to the GPU with gpuid
+      -- _distributeTensorRecursive(src,dst,srcGpuid,srcInd,dstGpuid,dstInd)
+      self.gradOutputGpu[gpuid] = self:_distributeTensorRecursive(gradOutput,
+         self.gradOutputGpu[gpuid], baseGpuid, baseGpuIndex, gpuid, i, #self.modules)
+   end
 
-  -- update gradInput for each module asynchronously
-  for i, module in ipairs(self.modules) do   
-    local gpuid = self.gpu_assignments[i]
-    setDevice(gpuid)
-    self.gradInput_gpu[gpuid] = module:updateGradInput(self.input_gpu[gpuid],
-      self.gradOutput_gpu[gpuid])
-  end
-  
-  cutorch.synchronize()
+   cutorch.synchronize()
 
-  -- concatenate the outputs to the base GPU
-  for i = 1, #self.modules do
-    local gpuid = self.gpu_assignments[i]
-    -- Merge the tensors in the input nested table to the GPU with gpuid
-    -- _ConcatTensorRecursive(src,dst,src_gpuid,src_ind,dst_gpuid,dst_ind)
-    self.gradInput = self:_ConcatTensorRecursive(self.gradInput_gpu[gpuid], 
-      self.gradInput, gpuid, i, base_gpuid, base_gpu_index)
-  end
-  
-  cutorch.synchronize()
+   -- update gradInput for each module asynchronously
+   for i, module in ipairs(self.modules) do
+      local gpuid = self.gpuAssignments[i]
+      setDevice(gpuid)
+      self.gradInputGpu[gpuid] = module:updateGradInput(self.inputGpu[gpuid],
+      self.gradOutputGpu[gpuid])
+   end
 
-  setDevice(prev_gpuid)
+   cutorch.synchronize()
 
-  return self.gradInput
+   -- concatenate the outputs to the base GPU
+   for i = 1, #self.modules do
+      local gpuid = self.gpuAssignments[i]
+      -- Merge the tensors in the input nested table to the GPU with gpuid
+      -- _concatTensorRecursive(src,dst,srcGpuid,srcInd,dstGpuid,dstInd)
+      self.gradInput = self:_concatTensorRecursive(self.gradInputGpu[gpuid],
+         self.gradInput, gpuid, i, baseGpuid, baseGpuIndex, #self.modules)
+   end
+
+   cutorch.synchronize()
+
+   setDevice(prevGpuid)
+
+   return self.gradInput
 end
 
 function DataParallelTable:accGradParameters(input, gradOutput, scale)
-  -- We assume updateGradInput has already been called (so gradOutput has
-  -- already been populated)
-  local prev_gpuid = cutorch.getDevice()
-  local base_gpuid = self.gpu_assignments[base_gpu_index]
-  
-  scale = scale or 1
-  -- Calculate the gradWeight + gradBias on each sub-module
-  for i, module in ipairs(self.modules) do
-    local gpuid = self.gpu_assignments[i]
-    setDevice(gpuid)
-    module:accGradParameters(self.input_gpu[gpuid], self.gradOutput_gpu[gpuid],
-      scale)
-  end
-  
-  cutorch.synchronize()  -- We have to wait until accGradParameters has finished
-  
-  -- Accumulate the gradients onto one GPU (the first one)
-  -- TODO: Parallelize this (ie a parallel merge)
-  base_params, base_grad_params = self.modules[base_gpu_index]:parameters()
-  --print(base_grad_params)  -- TODO: Temp code
-  for i, module in ipairs(self.modules) do
-    if (i ~= base_gpu_index) then
-      params, grad_params = self.modules[i]:parameters()
-      deepTensorsAdd(base_grad_params, grad_params)  -- dst, src
-      cutorch.synchronize()
-    end
-  end
+   -- We assume updateGradInput has already been called (so gradOutput has
+   -- already been populated)
+   local prevGpuid = cutorch.getDevice()
+   local baseGpuid = self.gpuAssignments[baseGpuIndex]
 
-  setDevice(prev_gpuid)
+   scale = scale or 1
+   -- Calculate the gradWeight + gradBias on each sub-module
+   for i, module in ipairs(self.modules) do
+      local gpuid = self.gpuAssignments[i]
+      setDevice(gpuid)
+      module:accGradParameters(self.inputGpu[gpuid], self.gradOutputGpu[gpuid],
+      scale)
+   end
+
+   cutorch.synchronize()  -- We have to wait until accGradParameters has finished
+
+   -- Accumulate the gradients onto one GPU (the first one)
+   -- TODO: Parallelize this (ie a parallel merge)
+   local baseParams, baseGradParams = self.modules[baseGpuIndex]:parameters()
+   for i, module in ipairs(self.modules) do
+      if (i ~= baseGpuIndex) then
+         local params, gradParams = self.modules[i]:parameters()
+         deepTensorsAdd(baseGradParams, gradParams)  -- dst, src
+         cutorch.synchronize()
+      end
+   end
+
+   setDevice(prevGpuid)
 end
 
 function DataParallelTable:syncParameters()
-  local prev_gpuid = cutorch.getDevice()
-  base_params, base_grad_params = self.modules[base_gpu_index]:parameters()
-  -- TODO: Parallelize this (ie a parallel copy)
-  for i, module in ipairs(self.modules) do
-    if (i ~= base_gpu_index) then
-      params, grad_params = self.modules[i]:parameters()
-      deepTensorsCopy(params, base_params)  -- dst, src
-    end
-  end
-  cutorch.synchronize()
-  
-  setDevice(prev_gpuid)
+   local prevGpuid = cutorch.getDevice()
+   local baseParams, baseGradParams = self.modules[baseGpuIndex]:parameters()
+   -- TODO: Parallelize this (ie a parallel copy)
+   for i, module in ipairs(self.modules) do
+      if (i ~= baseGpuIndex) then
+         local params, gradParams = self.modules[i]:parameters()
+         deepTensorsCopy(params, baseParams)  -- dst, src
+      end
+   end
+   cutorch.synchronize()
+
+   setDevice(prevGpuid)
 end
 
 -- For compatability with nn.Optim from fbcunn
-function DataParallelTable:_mixGrads()
-  self:syncParameters()
+function DataParallelTable:MixGrads()
+   self:syncParameters()
 end
 
 function DataParallelTable:accUpdateGradParameters(input, gradOutput, lr)
-  error("accUpdateGradParameters not supported for DataParallelTable.")
+   error("accUpdateGradParameters not supported for DataParallelTable.")
 end
 
 function DataParallelTable:zeroGradParameters()
-  local prev_gpuid = cutorch.getDevice()
-  for i, module in ipairs(self.modules) do
-    setDevice(self.gpu_assignments[i])
-    module:zeroGradParameters()
-  end
-  setDevice(prev_gpuid)
+   local prevGpuid = cutorch.getDevice()
+   for i, module in ipairs(self.modules) do
+      setDevice(self.gpuAssignments[i])
+      module:zeroGradParameters()
+   end
+   setDevice(prevGpuid)
 end
 
 function DataParallelTable:updateParameters(learningRate)
-  error("updateParameters not supported for DataParallelTable.")
+   error("updateParameters not supported for DataParallelTable.")
 end
 
 function DataParallelTable:parameters()
-  local prev_gpuid = cutorch.getDevice()
-  setDevice(self.gpu_assignments[1])
-  local ret = {self.modules[1]:parameters()}
-  setDevice(prev_gpuid)
-  return unpack(ret)
+   local prevGpuid = cutorch.getDevice()
+   setDevice(self.gpuAssignments[1])
+   local ret = {self.modules[1]:parameters()}
+   setDevice(prevGpuid)
+   return unpack(ret)
 end
 
 function DataParallelTable:share(mlp,...)
-  error("Share not supported for DataParallelTable.")
+   error("Share not supported for DataParallelTable.")
 end
 
 function DataParallelTable:clone()
-  error("clone not supported for DataParallelTable.")
+   error("clone not supported for DataParallelTable.")
 end
 
 function DataParallelTable:reset(stdv)
-  local prev_gpuid = cutorch.getDevice()
-  for i, module in ipairs(self.modules) do
-    setDevice(self.gpu_assignments[i])
-    module:reset(stdv)
-  end
-  setDevice(prev_gpuid)
+   local prevGpuid = cutorch.getDevice()
+   for i, module in ipairs(self.modules) do
+      setDevice(self.gpuAssignments[i])
+      module:reset(stdv)
+   end
+   setDevice(prevGpuid)
 end
 
 function DataParallelTable:name()
-  return 'DataParallelTable'
+   return 'DataParallelTable'
 end
 
-function DataParallelTable:type(type_str)
-  error("type() not supported for DataParallelTable.")
+function DataParallelTable:type(typeStr)
+   error("type() not supported for DataParallelTable.")
 end
 
-function DataParallelTable:_calculateSliceRange(tensor, id)
-  local outerDim = tensor:size(self.dimension)
-  if outerDim % #self.modules ~= 0 then
-    error("cannot evenly divide " .. outerDim .. " inputs to " ..
-      #self.modules .. " modules")
-  end
-  local eltsPerMod = outerDim / #self.modules
-  local rangeStart = (id - 1) * eltsPerMod + 1
-  local rangeEnd = rangeStart + eltsPerMod - 1
-  return {rangeStart, rangeEnd}
+function DataParallelTable:_calculateSliceRange(tensor, id, total)
+   local outerDim = tensor:size(self.dimension)
+   local eltsPerMod = torch.round( outerDim / #self.modules )
+   local rangeStart = (id - 1) * eltsPerMod + 1
+   local rangeEnd = rangeStart + eltsPerMod - 1
+   if id == total then
+      rangeEnd = outerDim
+   end
+   self.batchSize = outerDim -- TODO: this is a hack to propagate batchSize to line 494
+                             --       but might not be generic enough
+   return {rangeStart, rangeEnd}
 end
 
 -- _distributeTensorRecursive - if the src is a tensor then the function slices
--- it long self.dimension and copies each portion into each child module. 
+-- it long self.dimension and copies each portion into each child module.
 -- Otherwise it does a recursive call on tables.
-function DataParallelTable:_distributeTensorRecursive(src, dst, src_gpuid, 
-  src_index, dst_gpuid, dst_index)
-  if (torch.type(src) == 'table') then
-    if torch.type(dst) ~= 'table' or #src ~= #dst then
-      dst = {}
-    end
+function DataParallelTable:_distributeTensorRecursive(src, dst,
+   srcGpuid, srcIndex, dstGpuid, dstIndex, nModules)
+   if (torch.type(src) == 'table') then
+      if torch.type(dst) ~= 'table' or #src ~= #dst then
+         dst = {}
+      end
 
-    -- Recurse on the table
-    for i = 1, #src do
-      dst[i] = self:_distributeTensorRecursive(src[i], dst[i], src_gpuid, 
-        src_index, dst_gpuid, dst_index)
-    end
+      -- Recurse on the table
+      for i = 1, #src do
+         dst[i] = self:_distributeTensorRecursive(src[i], dst[i], srcGpuid,
+         srcIndex, dstGpuid, dstIndex, nModules)
+      end
 
-  elseif torch.type(src):find('torch%..+Tensor') then  
-    if (dst == nil or torch.type(dst) ~= 'torch.CudaTensor') then
-      -- Allocate only on startup or when input table structure changes. 
-      -- Otherwise we will just resize the tensor below.
-      setDevice(dst_gpuid)
-      dst = torch.CudaTensor()
-    end
-
-    -- Split the tensor
-    assert(torch.typename(src) == 'torch.CudaTensor')
-    local slice = src[{ self:_calculateSliceRange(src, dst_index) }]
-
-    if not dst:isSameSizeAs(slice) then
-      setDevice(dst_gpuid)
-      dst:resizeAs(slice)
-    end
-
-    asyncGPUCopy(dst, slice)  -- dst, src
-  else
-    error('input must be a nested table of tensors!')
-  end
-
-  return dst  
-end
-
--- _ConcatTensorRecursive - if the src is a tensor then the function copies it
--- into the dst slice along self.dimension. 
--- Otherwise it does a recursive call on tables.
-function DataParallelTable:_ConcatTensorRecursive(src, dst, src_gpuid, 
-  src_index, dst_gpuid, dst_index)
-  if (torch.type(src) == 'table') then
-    if torch.type(dst) ~= 'table' or #src ~= #dst then
-      dst = {}
-    end
-
-    -- Recurse on the table
-    for i = 1, #src do
-      dst[i] = self:_ConcatTensorRecursive(src[i], dst[i], src_gpuid, 
-        src_index, dst_gpuid, dst_index)
-    end
-
-  elseif torch.type(src):find('torch%..+Tensor') then  
-    if (dst == nil or torch.type(dst) ~= 'torch.CudaTensor') then
-      -- Allocate only on startup or when input table structure changes. 
-      -- Otherwise we will just resize the tensor below.
-      setDevice(dst_gpuid)
-      dst = torch.CudaTensor()
-    end
-    
-    if (torch.numel(src) > 0) then
-      -- Some modules return empty gradInputs if they don't actually return 
-      -- anything.
-      local dst_size = src:size():totable()
-      dst_size[self.dimension] = dst_size[self.dimension] * #self.modules
-      if not (equalSize(dst:size():totable(), dst_size)) then
-        setDevice(dst_gpuid)
-        dst:resize(unpack(dst_size))
+   elseif torch.type(src):find('torch%..+Tensor') then
+      if (dst == nil or torch.type(dst) ~= 'torch.CudaTensor') then
+         -- Allocate only on startup or when input table structure changes.
+         -- Otherwise we will just resize the tensor below.
+         setDevice(dstGpuid)
+         dst = torch.CudaTensor()
       end
 
       -- Split the tensor
       assert(torch.typename(src) == 'torch.CudaTensor')
-      local slice = dst[{ self:_calculateSliceRange(dst, src_index) }]
+      local slice = src[{self:_calculateSliceRange(src, dstIndex, nModules)}]
 
-      asyncGPUCopy(slice, src)  -- dst, src
-    end
-  else
-    error('input must be a nested table of tensors!')
-  end
+      if not dst:isSameSizeAs(slice) then
+         setDevice(dstGpuid)
+         dst:resizeAs(slice)
+      end
 
-  return dst  
+      asyncGPUCopy(dst, slice)  -- dst, src
+   else
+      error('input must be a nested table of tensors!')
+   end
+
+   return dst
+end
+
+-- _concatTensorRecursive - if the src is a tensor then the function copies it
+-- into the dst slice along self.dimension.
+-- Otherwise it does a recursive call on tables.
+function DataParallelTable:_concatTensorRecursive(src, dst, srcGpuid,
+   srcIndex, dstGpuid, dstIndex, nModules)
+   if (torch.type(src) == 'table') then
+      if torch.type(dst) ~= 'table' or #src ~= #dst then
+         dst = {}
+      end
+
+      -- Recurse on the table
+      for i = 1, #src do
+         dst[i] = self:_concatTensorRecursive(src[i], dst[i], srcGpuid,
+            srcIndex, dstGpuid, dstIndex, nModules)
+      end
+
+   elseif torch.type(src):find('torch%..+Tensor') then
+      if (dst == nil or torch.type(dst) ~= 'torch.CudaTensor') then
+         -- Allocate only on startup or when input table structure changes.
+         -- Otherwise we will just resize the tensor below.
+         setDevice(dstGpuid)
+         dst = torch.CudaTensor()
+      end
+
+      if (torch.numel(src) > 0) then
+         -- Some modules return empty gradInputs if they don't actually return
+         -- anything.
+         local dstSize = src:size():totable()
+         dstSize[self.dimension] = self.batchSize
+         if not (equalSize(dst:size():totable(), dstSize)) then
+            setDevice(dstGpuid)
+            dst:resize(unpack(dstSize))
+         end
+
+         -- Split the tensor
+         assert(torch.typename(src) == 'torch.CudaTensor')
+         local slice = dst[{ self:_calculateSliceRange(dst, srcIndex, nModules) }]
+
+         asyncGPUCopy(slice, src)  -- dst, src
+      end
+   else
+      error('input must be a nested table of tensors!')
+   end
+
+   return dst
 end

--- a/test_DataParallelTable.lua
+++ b/test_DataParallelTable.lua
@@ -2,301 +2,303 @@ require 'cunn'
 require 'optim'
 
 -- If fbcunn and fbnn exists we'll do a profile of DataParallel
-profile_dp = pcall(function() require 'fbcunn'; require 'fbnn' end)
+local profileDp = pcall(function() require 'fbcunn'; require 'fbnn' end)
 
-local base_gpu = 1  -- First GPU to use
-local num_gpus = cutorch.getDeviceCount()
+local baseGpu = 1  -- First GPU to use
+local numGpus = cutorch.getDeviceCount()
 torch.setdefaulttensortype('torch.DoubleTensor')
 torch.setnumthreads(8)
-cutorch.setDevice(base_gpu)
+cutorch.setDevice(baseGpu)
 
 -- Create an instance of the test framework
 local precision = 1e-5
-local loose_precision = 1e-4
+local loosePrecision = 1e-4
 local mytester = torch.Tester()
 local jac = nn.Jacobian
 local test = {}
 
-function copyTable(x)  -- Shallow copy
-  local ret = {}
-  for key, value in pairs(x) do ret[key] = value end
-  return ret
+local function copyTable(x)  -- Shallow copy
+   local ret = {}
+   for key, value in pairs(x) do ret[key] = value end
+   return ret
 end
 
-function createSplitNetwork(dim, dim_size)
-  local split = nn.ConcatTable()
-  for i = 1, dim_size do 
-    split:add(nn.Narrow(dim, i, 1)) 
-  end
-  return split
+local function createSplitNetwork(dim, dimSize)
+   local split = nn.ConcatTable()
+   for i = 1, dimSize do
+      split:add(nn.Narrow(dim, i, 1))
+   end
+   return split
 end
 
 -- Build a binary classifier that takes in a table of tensors and outputs
 -- a table of tensors.  We will split the BATCHES across GPUs.
-function buildNet(width, height, pool, feat, filt, table_in_out, num_convs)
-  local net = nn.Sequential()
-  if table_in_out then
-    net:add(nn.JoinTable(2))  -- Join R,G,B tensors into RGB
-  end
-  assert(math.fmod(filt,2) == 1)
-  for i = 1, num_convs do
-    local fin = 3
-    if (i > 1) then fin = feat end
-    net:add(nn.SpatialConvolutionMM(fin, feat, filt, filt, 1, 1, (filt-1)/2))
-    net:add(nn.Threshold())
-  end
-  net:add(nn.SpatialMaxPooling(pool, pool))
-  net:add(nn.Reshape(width * height * feat / (pool * pool)))
-  net:add(nn.Linear(width * height * feat / (pool * pool), 2))
-  -- net:add(nn.SoftMax())  -- This is fake anyway, so just do regression :-)
-  if table_in_out then
-    net:add(createSplitNetwork(2,2))
-  end
-  return net
+local function buildNet(width, height, pool, feat, filt, tableInOut, numConvs)
+   local net = nn.Sequential()
+   if tableInOut then
+      net:add(nn.JoinTable(2))  -- Join R,G,B tensors into RGB
+   end
+   assert(math.fmod(filt,2) == 1)
+   for i = 1, numConvs do
+      local fin = 3
+      if (i > 1) then fin = feat end
+      net:add(nn.SpatialConvolutionMM(fin, feat, filt, filt, 1, 1, (filt-1)/2))
+      net:add(nn.Threshold())
+   end
+   net:add(nn.SpatialMaxPooling(pool, pool))
+   net:add(nn.Reshape(width * height * feat / (pool * pool)))
+   net:add(nn.Linear(width * height * feat / (pool * pool), 2))
+   -- net:add(nn.SoftMax())  -- This is fake anyway, so just do regression :-)
+   if tableInOut then
+      net:add(createSplitNetwork(2,2))
+   end
+   return net
 end
 
 function test.DataParallelTable()
-  collectgarbage()
-  local width = 16
-  local height = 16
-  local pool = 4
-  local feat = 8
-  local filt = 5
-  local num_convs = 2
-  local num_sgd_steps = 10
-  local sync_gpu_cpu_params_every = 4
-  
-  assert(num_gpus > 1)
-  local batch_size = 2 * num_gpus
-  
-  -- Build a CPU model
-  local cpu_classifier = buildNet(width, height, pool, feat, filt, true, 
-    num_convs)
+   local width = 16
+   local height = 16
+   local pool = 4
+   local feat = 8
+   local filt = 5
+   local numConvs = 2
+   local numSgdSteps = 10
+   local syncGpuCpuParamsEvery = 4
+   assert(numGpus > 1)
 
-  -- Build a multi-GPU model
-  local g_classifier = nn.DataParallelTable(1)
-  for i = 1, num_gpus do
-    local cur_gpu = math.fmod(base_gpu+(i-1)-1, cutorch.getDeviceCount()) + 1
-    cutorch.setDevice(cur_gpu)
-    g_classifier:add(cpu_classifier:clone():cuda(), cur_gpu)
-  end
-  cutorch.setDevice(base_gpu)
+   -- test for various batchSizes, not necessarily multiples of nGpus:
+   for _,batchSize in ipairs {2 * numGpus, 9, 15} do
+      collectgarbage()
 
-  -- Now wrap them in layers that will split up the input tensor and join the
-  -- output tensor (I know this seems stupid - and it is - but we need to test
-  -- DataParallelTable under table inputs and when it is embedded in a network.
-  local c_net = nn.Sequential()
-  c_net:add(createSplitNetwork(2,3))
-  c_net:add(cpu_classifier)
-  c_net:add(nn.JoinTable(2))
-  c_net:cuda()
+      -- Build a CPU model
+      local cpuClassifier = buildNet(width, height, pool, feat, filt, true,
+      numConvs)
 
-  local g_net = nn.Sequential()
-  g_net:add(createSplitNetwork(2,3))
-  g_net:add(g_classifier)
-  g_net:add(nn.JoinTable(2):cuda())
-  g_net:get(1):cuda()
-  g_net:get(3):cuda()
-  
-  local c_input = torch.rand(batch_size, 3, height, width):cuda()
-  local g_input = c_input:cuda()
-  local c_target = torch.rand(batch_size, 2):cuda()
-  local g_target = c_target:cuda():cuda()
-  
-  local c_params, c_gradParams = c_net:getParameters()
-  local g_params, g_gradParams = g_net:getParameters()
-  
-  assert(cutorch.getDevice() == base_gpu, 
-    'getParameters: didnt restore GPU state')
-  
-  -- Set up an MSE optimizer on the GPU and CPU
-  local optim_state_cpu = {
-    learningRate = 0.1,  -- Artificially big learning rate
-    weightDecay = 0,
-    momentum = 0.9,
-    dampening = 0,
-    learningRateDecay = 0,
-    nesterov = true,
-  }
-  local optim_state_gpu = copyTable(optim_state_cpu)
-  local optim_method = optim.sgd
-  
-  local criterion_cpu = nn.MSECriterion():cuda()
-  local criterion_gpu = criterion_cpu:clone():cuda()
-  
-  for i = 1, num_sgd_steps do
-    collectgarbage()
-    local feval_cpu = function(x)
-      if x ~= c_params then c_params:copy(x) end
-      c_net:zeroGradParameters()
-      -- FPROP + BPROP on CPU
-      local output = c_net:forward(c_input)
-      local err = criterion_cpu:forward(output, c_target)
-      local gradOutput = criterion_cpu:backward(output, c_target)
-      local gradInput = c_net:backward(c_input, gradOutput)
-      return err, c_gradParams
-    end
-    
-    local feval_gpu = function(x)
-      if x ~= g_params then g_params:copy(x) end
-      g_net:zeroGradParameters()
-      assert(cutorch.getDevice() == base_gpu, 
-        'zeroGradParameters: didnt restore GPU state')
-      -- FPROP + BPROP on GPU
-      local output = g_net:forward(g_input)
-      assert(cutorch.getDevice() == base_gpu, 
-        'DataParallelTable:forward didnt restore GPU state')
-      local err = criterion_gpu:forward(output, g_target)
-      local gradOutput = criterion_gpu:backward(output, g_target)
-      local gradInput = g_net:backward(g_input, gradOutput)
-      assert(cutorch.getDevice() == base_gpu, 
-        'DataParallelTable:add didnt restore GPU state')
-      return err, g_gradParams
-    end
-    
-    -- Perform an SGD step on the GPU and CPU
-    optim_method(feval_cpu, c_params, optim_state_cpu)
-    optim_method(feval_gpu, g_params, optim_state_gpu)
-    g_net:findModules('nn.DataParallelTable')[1]:syncParameters()
-    assert(cutorch.getDevice() == base_gpu, 
-      'DataParallelTable:syncParameters didnt restore GPU state')
-    
-    -- Now make sure that everything is the same
-    local c_output = c_net.output
-    local g_output = g_net.output
-    local c_gradInput = c_net.gradInput
-    local g_gradInput = g_net.gradInput
-  
-    mytester:assertlt((c_output:float() - g_output:float()):abs():max(), 
-      precision, 'fprop error ')
-    mytester:assertlt((criterion_cpu.gradInput:float() - 
-      criterion_gpu.gradInput:float()):abs():max(), precision, 
-      'CRITERION BPROP error ')
-    mytester:assertlt((c_params:float() - g_params:float()):abs():max(),
-      precision, 'parameters error ')
-    mytester:assertlt((c_gradParams:float() - g_gradParams:float()):abs():max(), 
-      precision, 'BPROP error (gradParams)')
-    mytester:assertlt((c_gradInput:float() - g_gradInput:float()):abs():max(),
-      precision, 'BPROP error (gradInput)')
-    
-    -- Sync the CPU and GPU weights every few "epochs" to prevent floating point
-    -- drift between SGD iterations (ie, they will eventually be divergent after
-    -- enough iters)
-    if math.fmod(i, sync_gpu_cpu_params_every) == 0 then
-      local cp = c_net:parameters()
-      local gp = g_net:get(2):get(1):parameters()
-      assert(#cp == #gp)
-      for j = 1, #cp do 
-        cp[j]:copy(gp[j]) 
+      -- Build a multi-GPU model
+      local gClassifier = nn.DataParallelTable(1)
+      for i = 1, numGpus do
+         local curGpu = math.fmod(baseGpu+(i-1)-1, cutorch.getDeviceCount()) + 1
+         cutorch.setDevice(curGpu)
+         gClassifier:add(cpuClassifier:clone():cuda(), curGpu)
       end
-    end
-  end
+      cutorch.setDevice(baseGpu)
+
+      -- Now wrap them in layers that will split up the input tensor and join the
+      -- output tensor (I know this seems stupid - and it is - but we need to test
+      -- DataParallelTable under table inputs and when it is embedded in a network.
+      local cNet = nn.Sequential()
+      cNet:add(createSplitNetwork(2,3))
+      cNet:add(cpuClassifier)
+      cNet:add(nn.JoinTable(2))
+      cNet:cuda()
+
+      local gNet = nn.Sequential()
+      gNet:add(createSplitNetwork(2,3))
+      gNet:add(gClassifier)
+      gNet:add(nn.JoinTable(2):cuda())
+      gNet:get(1):cuda()
+      gNet:get(3):cuda()
+
+      local cInput = torch.rand(batchSize, 3, height, width):cuda()
+      local gInput = cInput:cuda()
+      local cTarget = torch.rand(batchSize, 2):cuda()
+      local gTarget = cTarget:cuda():cuda()
+
+      local cParams, cGradParams = cNet:getParameters()
+      local gParams, gGradParams = gNet:getParameters()
+
+      assert(cutorch.getDevice() == baseGpu,
+      'getParameters: didnt restore GPU state')
+
+      -- Set up an MSE optimizer on the GPU and CPU
+      local optimStateCpu = {
+         learningRate = 0.1,  -- Artificially big learning rate
+         weightDecay = 0,
+         momentum = 0.9,
+         dampening = 0,
+         learningRateDecay = 0,
+         nesterov = true,
+      }
+      local optimStateGpu = copyTable(optimStateCpu)
+      local optimMethod = optim.sgd
+
+      local criterionCpu = nn.MSECriterion():cuda()
+      local criterionGpu = criterionCpu:clone():cuda()
+
+      for i = 1, numSgdSteps do
+         collectgarbage()
+         local fevalCpu = function(x)
+            if x ~= cParams then cParams:copy(x) end
+            cNet:zeroGradParameters()
+            -- FPROP + BPROP on CPU
+            local output = cNet:forward(cInput)
+            local err = criterionCpu:forward(output, cTarget)
+            local gradOutput = criterionCpu:backward(output, cTarget)
+            local gradInput = cNet:backward(cInput, gradOutput)
+            return err, cGradParams
+         end
+
+         local fevalGpu = function(x)
+            if x ~= gParams then gParams:copy(x) end
+            gNet:zeroGradParameters()
+            assert(cutorch.getDevice() == baseGpu,
+            'zeroGradParameters: didnt restore GPU state')
+            -- FPROP + BPROP on GPU
+            local output = gNet:forward(gInput)
+            assert(cutorch.getDevice() == baseGpu,
+            'DataParallelTable:forward didnt restore GPU state')
+            local err = criterionGpu:forward(output, gTarget)
+            local gradOutput = criterionGpu:backward(output, gTarget)
+            local gradInput = gNet:backward(gInput, gradOutput)
+            assert(cutorch.getDevice() == baseGpu,
+            'DataParallelTable:add didnt restore GPU state')
+            return err, gGradParams
+         end
+
+         -- Perform an SGD step on the GPU and CPU
+         optimMethod(fevalCpu, cParams, optimStateCpu)
+         optimMethod(fevalGpu, gParams, optimStateGpu)
+         gNet:findModules('nn.DataParallelTable')[1]:syncParameters()
+         assert(cutorch.getDevice() == baseGpu,
+         'DataParallelTable:syncParameters didnt restore GPU state')
+
+         -- Now make sure that everything is the same
+         local cOutput = cNet.output
+         local gOutput = gNet.output
+         local cGradInput = cNet.gradInput
+         local gGradInput = gNet.gradInput
+
+         mytester:assertlt((cOutput:float() - gOutput:float()):abs():max(),
+         precision, 'fprop error ')
+         mytester:assertlt((criterionCpu.gradInput:float() -
+         criterionGpu.gradInput:float()):abs():max(), precision,
+         'CRITERION BPROP error ')
+         mytester:assertlt((cParams:float() - gParams:float()):abs():max(),
+         precision, 'parameters error ')
+         mytester:assertlt((cGradParams:float() - gGradParams:float()):abs():max(),
+         precision, 'BPROP error (gradParams)')
+         mytester:assertlt((cGradInput:float() - gGradInput:float()):abs():max(),
+         precision, 'BPROP error (gradInput)')
+
+         -- Sync the CPU and GPU weights every few "epochs" to prevent floating point
+         -- drift between SGD iterations (ie, they will eventually be divergent after
+         -- enough iters)
+         if math.fmod(i, syncGpuCpuParamsEvery) == 0 then
+            local cp = cNet:parameters()
+            local gp = gNet:get(2):get(1):parameters()
+            assert(#cp == #gp)
+            for j = 1, #cp do
+               cp[j]:copy(gp[j])
+            end
+         end
+      end
+   end
 end
 
 function test.ProfileDataParallelTable()
-  local width = 32
-  local height = 32
-  local pool = 4
-  local feat = 128
-  local filt = 7
-  local num_convs = 4
-  local num_repeats = 10
-  
-  local modules_to_test = {}
-  modules_to_test['DataParallelTable'] = nn.DataParallelTable
-  if profile_dp then 
-    modules_to_test['DataParallel'] = nn.DataParallel 
-  end 
-  
-  local device_count = num_gpus
-  assert(device_count > 1)
-  print('')
-  
-  for module_name, module in pairs(modules_to_test) do
-    for num_gpus = 1, device_count do 
-      collectgarbage()
-      print('Profiling ' .. module_name .. ' with ' .. num_gpus .. ' gpus')
-      local batch_size = 2 * 3 * 4
-      assert(math.fmod(batch_size, num_gpus) == 0)
-      
-      -- Build a CPU model
-      local c_net = buildNet(width, height, pool, feat, filt, false, num_convs)
+   local width = 32
+   local height = 32
+   local pool = 4
+   local feat = 128
+   local filt = 7
+   local numConvs = 4
+   local numRepeats = 10
 
-      -- Build a multi-GPU model
-      local g_net = module(1)
-      if (module_name == 'DataParallel') then
-        cutorch.setDevice(base_gpu)
-        g_net:cuda()
+   local modulesToTest = {}
+   modulesToTest['DataParallelTable'] = nn.DataParallelTable
+   if profileDp then
+      modulesToTest['DataParallel'] = nn.DataParallel
+   end
+
+   local deviceCount = numGpus
+   assert(deviceCount > 1)
+   print('')
+
+   for moduleName, module in pairs(modulesToTest) do
+      for numGpus = 1, deviceCount do
+         collectgarbage()
+         print('Profiling ' .. moduleName .. ' with ' .. numGpus .. ' gpus')
+         local batchSize = 2 * 3 * 4
+         assert(math.fmod(batchSize, numGpus) == 0)
+
+         -- Build a CPU model
+         local cNet = buildNet(width, height, pool, feat, filt, false, numConvs)
+
+         -- Build a multi-GPU model
+         local gNet = module(1)
+         if (moduleName == 'DataParallel') then
+            cutorch.setDevice(baseGpu)
+            gNet:cuda()
+         end
+         for i = 1, numGpus do
+            local curGpu = math.fmod(baseGpu+(i-1)-1, cutorch.getDeviceCount())+1
+            cutorch.setDevice(curGpu)
+            gNet:add(cNet:clone():cuda(), curGpu)
+         end
+         cutorch.setDevice(baseGpu)
+
+         local input = torch.rand(batchSize, 3, height, width):cuda()
+         local target = torch.rand(batchSize, 2):cuda()
+
+         local gParams, gGradParams
+         if (moduleName == 'DataParallelTable') then
+            gParams, gGradParams = gNet:getParameters()
+         end
+
+         -- Set up an MSE optimizer on the GPU
+         local optimState = {
+            learningRate = 0.1,
+            weightDecay = 0,
+            momentum = 0.9,
+            dampening = 0,
+            learningRateDecay = 0,
+            nesterov = true,
+         }
+         local optimMethod = optim.sgd
+         local criterion = nn.MSECriterion():cuda()
+         local timeGpuNet = 0
+
+         local opt
+         if (moduleName == 'DataParallel') then
+            opt = nn.Optim(gNet, optimState)
+         end
+
+         -- Call forward and backward once to hide allocations in profile
+         do
+            local output = gNet:forward(input)
+            gNet:backward(input, output)
+         end
+
+         for i = 1, numRepeats do
+            collectgarbage()
+
+            local fevalGpu = function(x)
+               if x ~= gParams then gParams:copy(x) end
+               gNet:zeroGradParameters()
+               local output = gNet:forward(input)
+               local err = criterion:forward(output, target)
+               local gradOutput = criterion:backward(output, target)
+               local gradInput = gNet:backward(input, gradOutput)
+               return err, gGradParams
+            end
+
+            -- Perform an SGD step and profile it
+            sys.tic()
+            if (moduleName == 'DataParallelTable') then
+               optimMethod(fevalGpu, gParams, optimState)
+               gNet:findModules('nn.DataParallelTable')[1]:syncParameters()
+            else
+               opt:optimize(optim.sgd, input, target, criterion)
+            end
+            cutorch.synchronize()
+            timeGpuNet = timeGpuNet + sys.toc()
+
+            collectgarbage()
+         end
+
+         print('  Time per FPROP+BPROP: ' .. timeGpuNet / numRepeats)
       end
-      for i = 1, num_gpus do
-        local cur_gpu = math.fmod(base_gpu+(i-1)-1, cutorch.getDeviceCount())+1
-        cutorch.setDevice(cur_gpu)
-        g_net:add(c_net:clone():cuda(), cur_gpu)
-      end
-      cutorch.setDevice(base_gpu)
-      
-      local input = torch.rand(batch_size, 3, height, width):cuda()
-      local target = torch.rand(batch_size, 2):cuda()
-      
-      local g_params, g_gradParams
-      if (module_name == 'DataParallelTable') then
-        g_params, g_gradParams = g_net:getParameters()
-      end
-      
-      -- Set up an MSE optimizer on the GPU
-      local optim_state = {
-        learningRate = 0.1,
-        weightDecay = 0,
-        momentum = 0.9,
-        dampening = 0,
-        learningRateDecay = 0,
-        nesterov = true,
-      }
-      local optim_method = optim.sgd 
-      local criterion = nn.MSECriterion():cuda()
-      local time_gpu_net = 0
-      
-      local opt
-      if (module_name == 'DataParallel') then
-        opt = nn.Optim(g_net, optim_state)
-      end
-      
-      -- Call forward and backward once to hide allocations in profile
-      do
-        local output = g_net:forward(input)
-        g_net:backward(input, output)
-      end
-      
-      for i = 1, num_repeats do
-        collectgarbage()
-         
-        local feval_gpu = function(x)
-          if x ~= g_params then g_params:copy(x) end
-          g_net:zeroGradParameters()
-          local output = g_net:forward(input)
-          local err = criterion:forward(output, target)
-          local gradOutput = criterion:backward(output, target)
-          local gradInput = g_net:backward(input, gradOutput)
-          return err, g_gradParams
-        end
-        
-        -- Perform an SGD step and profile it 
-        sys.tic()
-        if (module_name == 'DataParallelTable') then
-          optim_method(feval_gpu, g_params, optim_state)
-          g_net:findModules('nn.DataParallelTable')[1]:syncParameters()
-        else
-          opt:optimize(optim.sgd, input, target, criterion)
-        end
-        cutorch.synchronize()
-        time_gpu_net = time_gpu_net + sys.toc()
-        
-        collectgarbage()
-      end
-      
-      print('  Time per FPROP+BPROP: ' .. time_gpu_net / num_repeats)
-    end
-  end
+   end
 end
 
 -- Now run the test above


### PR DESCRIPTION
- cleaned up syntax (camelCase)
- got rid of global variables (use th -g to monitor globals);
  there were 2 of them in DataParallelTable
- supporting batches of arbitrary sizes: do not have to be
  multiples of nb of GPUs anymore; added tests for that
  (so 3 GPUs can be used for batches of size 128, and 
   for cases where batch size varies dynamically, everything
   still works)