### PR TITLE
Fix index error when length is more than 1024 for TemporalMaxPooling

### DIFF
--- a/TemporalMaxPooling.cu
+++ b/TemporalMaxPooling.cu
@@ -135,11 +135,11 @@ static int cunn_TemporalMaxPooling_updateOutput(lua_State *L)
   }
 
   if (nthreads > TEMPORAL_MAX_POOLING_THREADS) {
-    nthreads = TEMPORAL_MAX_POOLING_THREADS;
     blocks.y = nthreads / TEMPORAL_MAX_POOLING_THREADS;
     if (nthreads % TEMPORAL_MAX_POOLING_THREADS > 0) {
       blocks.y += 1;
     }
+    nthreads = TEMPORAL_MAX_POOLING_THREADS;
   }
 
   dim3 threads(nthreads);
@@ -205,11 +205,11 @@ static int cunn_TemporalMaxPooling_updateGradInput(lua_State *L) {
   }
 
   if (nthreads > TEMPORAL_MAX_POOLING_THREADS) {
-    nthreads = TEMPORAL_MAX_POOLING_THREADS;
     blocks.y = nthreads / TEMPORAL_MAX_POOLING_THREADS;
     if (nthreads % TEMPORAL_MAX_POOLING_THREADS > 0) {
       blocks.y += 1;
     }
+    nthreads = TEMPORAL_MAX_POOLING_THREADS;
   }
 
   dim3 threads(nthreads);


### PR DESCRIPTION
This fixes issue #108. The bug was very obvious and simple.

Tested for both forward and backward propagation on inputs of huge lengths. Did not touch test because it may blow up the time, but let me know if you want it there.