### PR TITLE
Min and Max use THCudaTensor_min and THCudaTensor_max

### DIFF
--- a/Max.cu
+++ b/Max.cu
@@ -1,40 +1,5 @@
 #include "utils.h"
 
-/*
- * Description:
- *    this function finds the max along the innermost dimension
- *    Nd input, (N-1)d output, (N-1)d argmax
- */
-__global__ void max_output(float *input, float *output, float *indices,
-                           long nrows, long ncols)
-{
-  // output offset:
-  long o = threadIdx.x + blockDim.x * blockIdx.x;
-  if (o >= nrows) return;
-
-  // input offset:
-  long i = o * ncols;
-
-  // move pointers
-  input = input + i;
-
-  // compute max:
-  float max = input[0];
-  long argmax = 0;
-  long ii;
-  for (ii=1; ii<ncols; ii++) {
-      float val = input[ii];
-      if (val > max) {
-          max = val;
-          argmax = ii;
-      }
-  }
-
-  // store
-  output[o] = max;
-  indices[o] = argmax+1;
-}
-
 __global__ void max_gradInput(float *input, float *output, float *indices,
                               long nrows, long ncols)
 {
@@ -62,43 +27,7 @@ static int cunn_Max_updateOutput(lua_State *L)
   luaL_argcheck(L, dimension >= 0 && dimension < input->nDimension, 2, "dimension out of range");
   luaL_argcheck(L, dimension == input->nDimension-1, 2, "only supported dimension is innermost (CUDA kernel only)");
 
-  input = THCudaTensor_newContiguous(state, input);
-
-  THLongStorage *dim = THLongStorage_newWithSize(input->nDimension);
-  long i;
-  for(i = 0; i < input->nDimension; i++)
-    dim->data[i] = input->size[i];
-  dim->data[dimension] = 1;
-  THCudaTensor_resize(state, output, dim, NULL);
-  THCudaTensor_resize(state, indices, dim, NULL);
-  THLongStorage_free(dim);
-
-  float *input_data = THCudaTensor_data(state, input);
-  float *output_data = THCudaTensor_data(state, output);
-  float *indices_data = THCudaTensor_data(state, indices);
-
-  long nrows = THCudaTensor_nElement(state, output);
-  long ncols = input->size[dimension];
-
-  // cuda blocks & threads:
-  long nthreads = 256;
-  long nblocks = ceil((float)nrows / nthreads);
-  dim3 blocks(nblocks);
-  dim3 threads(nthreads);
-
-  // kernel:
-  max_output <<<blocks, threads,
-    0, THCState_getCurrentStream(state)>>> (input_data, output_data, indices_data, nrows, ncols);
-
-  // check for errors
-  cudaError_t err = cudaGetLastError();
-  if (err != cudaSuccess) {
-    printf("error in Max.updateOutput: %s\n", cudaGetErrorString(err));
-    THError("aborting");
-  }
-
-  // final cut:
-  THCudaTensor_free(state, input);
+  THCudaTensor_max(state, output, indices, input, dimension);
   THCudaTensor_select(state, output, NULL, dimension, 0);
 
   return 1;


### PR DESCRIPTION
This PR uses ```THCudaTensor_min``` and ```THCudaTensor_max``` allowing nn.Min and nn.Max inputs to be non-contiguous.

Now backward does not allow arbitrary dimension on input while forward does. Any ideas how to make backward with THC?