### PR TITLE
Add strides in SpatialAdaptiveMaxPooling to avoid memory copy in forward

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -1927,6 +1927,45 @@ function cunntest.SpatialAdaptiveMaxPooling_forward()
    mytester:asserteq(error_ind:max(), 0, 'error on indices (forward) ')
 end
 
+function cunntest.SpatialAdaptiveMaxPooling_forward_noncontig()
+   local from = math.random(1,64)
+   local to = from
+   local outi = math.random(2,64)
+   local outj = math.random(2,64)
+   local ini = math.random(10,256)
+   local inj = math.random(10,256)
+
+   local tm = {}
+   local title = string.format('SpatialAdaptiveMaxPooling.forward %s %dx%dx%d -> %dx%dx%d',
+                               'non-contiguous',from, inj, ini, to, outj, outi)
+   times[title] = tm
+
+   local input0 = torch.randn(from,ini,inj)
+   local input = input0:transpose(2,3)
+   local sconv = nn.SpatialAdaptiveMaxPooling(outi,outj)
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input0:cuda():transpose(2,3)
+   local gconv = nn.SpatialAdaptiveMaxPooling(outi,outj):cuda()
+   local rescuda = gconv:forward(input)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+   local error_ind = gconv.indices:float() - sconv.indices
+   mytester:asserteq(error_ind:max(), 0, 'error on indices (forward) ')
+end
+
 function cunntest.SpatialAdaptiveMaxPooling_forward_batch()
    local bs = math.random(4,10)
    local from = math.random(1,64)
@@ -1991,6 +2030,52 @@ function cunntest.SpatialAdaptiveMaxPooling_backward()
    tm.cpu = a:time().real
 
    input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = nn.SpatialAdaptiveMaxPooling(outi,outj):cuda()
+   gconv:forward(input)
+   gconv:zeroGradParameters()
+   local rescuda = gconv:backward(input, gradOutput)
+   a:reset()
+   for i = 1,nloop do
+      gconv:zeroGradParameters()
+      rescuda = gconv:backward(input, gradOutput)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
+function cunntest.SpatialAdaptiveMaxPooling_backward_noncontig()
+   local from = math.random(1,64)
+   local to = from
+   local outi = math.random(2,64)
+   local outj = math.random(2,64)
+   local ini = math.random(10,256)
+   local inj = math.random(10,256)
+
+   local tm = {}
+   local title = string.format('SpatialAdaptiveMaxPooling.backward %s %dx%dx%d -> %dx%dx%d',
+                               'non-contiguous', from, inj, ini, to, outj, outi)
+   times[title] = tm
+
+   local input0 = torch.randn(from,ini,inj)
+   local input = input0:transpose(2,3)
+   local gradOutput = torch.randn(to,outj,outi)
+   local sconv = nn.SpatialAdaptiveMaxPooling(outi,outj)
+   sconv:forward(input)
+   sconv:zeroGradParameters()
+   local groundgrad = sconv:backward(input, gradOutput)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      sconv:zeroGradParameters()
+      groundgrad = sconv:backward(input, gradOutput)
+   end
+   tm.cpu = a:time().real
+
+   input = input0:cuda():transpose(2,3)
    gradOutput = gradOutput:cuda()
    local gconv = nn.SpatialAdaptiveMaxPooling(outi,outj):cuda()
    gconv:forward(input)


### PR DESCRIPTION
Reduces the forward times for non-contiguous Tensors in the non-batched case by avoiding memory copies.