### PR TITLE
Optimized Spatial Batch Normalization

### DIFF
--- a/SpatialBatchNormalization.cu
+++ b/SpatialBatchNormalization.cu
@@ -1,0 +1,919 @@
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "SpatialBatchNormalization.cuh"
+
+/*
+  NOTE: This correctly handles only 3D/4D tensors with:
+  1. nBatch <= 32, and powers of two >=32 (64, 128, 256, 512, 1024)
+  2. nFeature any value <= 1024
+  3. nSpatial (iH x iW) in powers of two
+
+  This check is performed in nn/SpatialBatchNormalization.lua
+*/
+
+/* Helpers */
+inline int getSpatialChunkSize(int nBatch, int nSpatial) {
+   int threadsPerBatchDim = nBatch >= WARP_SIZE ? nBatch : WARP_SIZE;
+
+   return MAX_THREADS/threadsPerBatchDim > nSpatial ? nSpatial : MAX_THREADS/threadsPerBatchDim;
+}
+
+inline int getNumSpatialBlocks(int nSpatial) {
+   return nSpatial/MAX_THREADS == 0 ? 1 : nSpatial/MAX_THREADS;
+}
+
+static void cunn_SpatialBatchNormalization_transposeInput(THCState *state, THCudaTensor *input,
+                                                          THCudaTensor *transpose, int nBatch, int nFeature,
+                                                          int nSpatial) {
+   /*
+     Transpose
+
+     Two cases for input transpose:
+      - use coalesced write implementation for small spatial dim (< MAX_THREADS)
+      - use coalesced read implementation optimized for large spatial dimensions,
+        (uses all threads in a block)
+   */
+   int batchesInBlockTransp = MAX_THREADS/nBatch;
+   int spatialBlocksTransp = nSpatial/batchesInBlockTransp == 0 ? 1 : nSpatial/batchesInBlockTransp;
+
+   dim3 dimBlockTransp(MAX_THREADS, 1);
+   dim3 dimGridTransp(spatialBlocksTransp, nFeature);
+
+   if (nSpatial < MAX_THREADS) {
+      transposeInputClsdWrite_kernel<<<dimGridTransp, dimBlockTransp>>>(THCudaTensor_data(state, input),
+                                                                        THCudaTensor_data(state, transpose),
+                                                                        nBatch, nFeature, nSpatial,
+                                                                        batchesInBlockTransp);
+   } else {
+      spatialBlocksTransp = getNumSpatialBlocks(nSpatial);
+      dim3 dimBlockTransp2(MAX_THREADS, 1);
+      dim3 dimGridTransp2(nBatch, nFeature, spatialBlocksTransp);
+
+      transposeInputClsdRead_kernel<<<dimGridTransp2, dimBlockTransp2>>>(THCudaTensor_data(state, input),
+                                                                         THCudaTensor_data(state, transpose),
+                                                                         nBatch, nFeature, nSpatial);
+   }
+
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return;
+ }
+
+ static void cunn_SpatialBatchNormalization_transposeOutput(THCState *state, THCudaTensor *transposed,
+                                                           THCudaTensor *output, int nBatch, int nFeature,
+                                                           int nSpatial) {
+
+   int batchesInBlockTransp = MAX_THREADS/nBatch;
+   int spatialBlocksTransp = nSpatial/batchesInBlockTransp == 0 ? 1 : nSpatial/batchesInBlockTransp;
+   // remainder
+   spatialBlocksTransp = nSpatial % batchesInBlockTransp == 0 ? spatialBlocksTransp : spatialBlocksTransp + 1;
+
+   dim3 dimBlockTransp(MAX_THREADS, 1);
+   dim3 dimGridTransp(spatialBlocksTransp, nFeature);
+
+   transposeOutput_kernel<<<dimGridTransp, dimBlockTransp>>>(THCudaTensor_data(state, transposed),
+                                                             THCudaTensor_data(state, output),
+                                                             nBatch, nFeature, nSpatial, batchesInBlockTransp);
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return;
+}
+
+/*
+  NOTE: This correctly handles only 3D/4D tensors with:
+  1. nBatch <= 32, and powers of two >=32 (64, 128, 256, 512, 1024)
+  2. nFeature any value <= 1024
+  3. nSpatial (iH x iW) in powers of two
+*/
+
+static int cunn_SpatialBatchNormalization_forwardInferenceAffine(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 3);
+   int nFeature = (int)luaL_checknumber(L, 4);
+   int nSpatial = (int)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
+
+   // Pre-allocated buffers for the transposes
+   THCudaTensor *transposedInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+   THCudaTensor *transposedOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedOutput", "torch.CudaTensor");
+
+   // Output
+   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
+
+   THCudaTensor *running_mean = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "running_mean", "torch.CudaTensor");
+   THCudaTensor *running_std = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "running_std", "torch.CudaTensor");
+   THCudaTensor *weight = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "weight", "torch.CudaTensor");
+   THCudaTensor *bias = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "bias", "torch.CudaTensor");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 7, transposedInput, transposedOutput, output, weight, bias, running_mean, running_std));
+   luaL_argcheck(L, input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+
+   /* Transpose input */
+   cunn_SpatialBatchNormalization_transposeInput(state, input, transposedInput, nBatch, nFeature, nSpatial);
+
+   /*
+    -----
+    Block/thread dimensions for [nBatch x nFeature x nSpatial]
+    -----
+    blockIdx.x - gets a chunk of nSpatial dimension, depending on MAX_THREADS and the nBatch paramter.
+                 That is, each blockIdx.x handles as many nSpatial features as fits in its MAX_TREADS.
+                 If nBatch < 32, zero-pad to 32 so that one warp handles all batches in one spatial dim.
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nBatch dimension
+
+    For reductions, each block performs a local reduction of its values, across all the warps that span
+    the nBatch dimension. It then writes out the reduced (and normalized by nBatch) value to output[blockIdx.y].
+   */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+     in: transposedInput, running_mean, running_std
+     out: transposedOutput
+
+     Normalize the transposedInput based on running statistics.
+
+     transposedOutput[globalIndex] = (transposedInput[i] - mean) * std
+   */
+   spatialBatchNormalization_normalizeForwardInfAffine_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedInput),
+                                                                                               THCudaTensor_data(state, running_mean),
+                                                                                               THCudaTensor_data(state, running_std),
+                                                                                               THCudaTensor_data(state, weight),
+                                                                                               THCudaTensor_data(state, bias),
+                                                                                               THCudaTensor_data(state, transposedOutput),
+                                                                                               nBatch, nFeature, nSpatial,
+                                                                                               chunkSize);
+   /* Transpose output */
+   cunn_SpatialBatchNormalization_transposeOutput(state, transposedOutput, output, nBatch, nFeature, nSpatial);
+
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+
+static int cunn_SpatialBatchNormalization_forwardInference(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 3);
+   int nFeature = (int)luaL_checknumber(L, 4);
+   int nSpatial = (int)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
+
+   // Pre-allocated buffers for the transposes
+   THCudaTensor *transposedInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+   THCudaTensor *transposedOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedOutput", "torch.CudaTensor");
+
+   // Output
+   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
+
+   THCudaTensor *running_mean = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "running_mean", "torch.CudaTensor");
+   THCudaTensor *running_std = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "running_std", "torch.CudaTensor");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 5, transposedInput, transposedOutput, output, running_mean, running_std));
+   luaL_argcheck(L, input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+
+   /* Transpose input */
+   cunn_SpatialBatchNormalization_transposeInput(state, input, transposedInput, nBatch, nFeature, nSpatial);
+
+   /*
+    -----
+    Block/thread dimensions for [nBatch x nFeature x nSpatial]
+    -----
+    blockIdx.x - gets a chunk of nSpatial dimension, depending on MAX_THREADS and the nBatch paramter.
+                 That is, each blockIdx.x handles as many nSpatial features as fits in its MAX_TREADS.
+                 If nBatch < 32, zero-pad to 32 so that one warp handles all batches in one spatial dim.
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nBatch dimension
+
+    For reductions, each block performs a local reduction of its values, across all the warps that span
+    the nBatch dimension. It then writes out the reduced (and normalized by nBatch) value to output[blockIdx.y].
+   */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+     in: transposedInput, running_mean, running_std
+     out: transposedOutput
+
+     Normalize the transposedInput based on running statistics.
+
+     transposedOutput[globalIndex] = (transposedInput[i] - mean) * std
+   */
+   spatialBatchNormalization_normalizeForwardInfNoAffine_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedInput),
+                                                                                                 THCudaTensor_data(state, running_mean),
+                                                                                                 THCudaTensor_data(state, running_std),
+                                                                                                 THCudaTensor_data(state, transposedOutput),
+                                                                                                 nBatch, nFeature, nSpatial,
+                                                                                                 chunkSize);
+   /* Transpose output */
+   cunn_SpatialBatchNormalization_transposeOutput(state, transposedOutput, output, nBatch, nFeature, nSpatial);
+
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+
+
+static void cunn_SpatialBatchNormalization_updateOutputComputeStats(THCState *state,
+                                                                    THCudaTensor *input,
+                                                                    THCudaTensor *transposedInput,
+                                                                    THCudaTensor *batchAgg,
+                                                                    THCudaTensor *meanBuffer,
+                                                                    THCudaTensor *stdBuffer,
+                                                                    THCudaTensor *centered,
+                                                                    THCudaTensor *normalized,
+                                                                    int nBatch, int nFeature,
+                                                                    int nSpatial) {
+   /* Transpose input */
+   cunn_SpatialBatchNormalization_transposeInput(state, input, transposedInput, nBatch, nFeature, nSpatial);
+
+   /*
+    -----
+    Block/thread dimensions for [nBatch x nFeature x nSpatial]
+    -----
+    blockIdx.x - gets a chunk of nSpatial dimension, depending on MAX_THREADS and the nBatch paramter.
+                 That is, each blockIdx.x handles as many nSpatial features as fits in its MAX_TREADS.
+                 If nBatch < 32, zero-pad to 32 so that one warp handles all batches in one spatial dim.
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nBatch dimension
+
+    For reductions, each block performs a local reduction of its values, across all the warps that span
+    the nBatch dimension. It then writes out the reduced (and normalized by nBatch) value to output[blockIdx.y].
+   */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+    -----
+    Block/thread dimensions for [nFeature x nSpatial]
+    -----
+    blockIdx.x - chunk of nSpatial dimension (chunk size bound by MAX_THREADS)
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nSpatial dimension
+
+    In reduction, first all blocks do a local reduction of their chunk, then we reduce across blocks
+    using atomic operations.
+   */
+   int spatialBlocks = getNumSpatialBlocks(nSpatial);
+
+   dim3 dimBlockSpatial(MAX_THREADS, 1);
+   dim3 dimGridSpatial(spatialBlocks, nFeature);
+
+   /*
+     in: transposedInput
+     out: batchAgg
+
+     Compute mean across nBatch dimension of transposedInput.
+   */
+   spatialBatchNormalization_batchMean_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedInput),
+                                                                               THCudaTensor_data(state, batchAgg),
+                                                                               nBatch, nFeature, nSpatial,
+                                                                               chunkSize, true);
+   /*
+     in: batchAgg
+     out: meanBuffer
+
+     Compute *sum* across nSpatial dimension of batchAgg. Normalize by nSpatial in kernel(s) below.
+   */
+   spatialBatchNormalization_spatialAgg_kernel<<<dimGridSpatial, dimBlockSpatial>>>(THCudaTensor_data(state, batchAgg),
+                                                                                    THCudaTensor_data(state, meanBuffer),
+                                                                                    nBatch, nFeature, nSpatial);
+   /*
+     in: transposedInput, meanBuffer
+     out: batchAgg
+
+     Compute va across nBatch dimension of transposedInput.
+   */
+   spatialBatchNormalization_batchVar_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedInput),
+                                                                              THCudaTensor_data(state, meanBuffer),
+                                                                              THCudaTensor_data(state, batchAgg),
+                                                                              nBatch, nFeature, nSpatial, chunkSize);
+   /*
+     in: batchAgg
+     out: stdBuffer
+
+     Compute *sum* across nSpatial dimension of batchAgg. Normalize by nSpatial in kernel(s) below.
+   */
+   spatialBatchNormalization_spatialAgg_kernel<<<dimGridSpatial, dimBlockSpatial>>>(THCudaTensor_data(state, batchAgg),
+                                                                                    THCudaTensor_data(state, stdBuffer),
+                                                                                    nBatch, nFeature, nSpatial);
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return;
+}
+
+static void cunn_SpatialBatchNormalization_updateOutputNormStatsAndTranspose(THCState *state,
+                                                                             THCudaTensor *transposedOutput,
+                                                                             THCudaTensor *output,
+                                                                             THCudaTensor *meanBuffer,
+                                                                             THCudaTensor *stdBuffer,
+                                                                             float epsilon,
+                                                                             int nBatch, int nFeature,
+                                                                             int nSpatial) {
+   /*
+    -----
+    Block/thread dimensions for [nFeature]
+    -----
+    blockIdx.x - 2 blocks, id 0 for mean, 1 for std
+    threadIdx.x - over nFeature dimension
+   */
+   dim3 gridBlockMeanStd(nFeature);
+   dim3 dimGridMeanStd(2, 1);
+   float factor = 1.0f / (float)nSpatial;
+
+   /*
+     in: meanBuffer, stdBuffer
+     out: meanBuffer, stdBuffer
+
+     Normalize both the spatial mean and std (divide by nSpatial) and write out
+
+     mean[i] = mean[i] * factor
+     std[i] = std[i] * factor
+   */
+   spatialBatchNormalization_normalizeMeanStd_kernel<<<dimGridMeanStd, gridBlockMeanStd>>>(THCudaTensor_data(state, meanBuffer),
+                                                                                           THCudaTensor_data(state, stdBuffer),
+                                                                                           factor, epsilon, nFeature);
+
+   /* Transpose output back */
+   cunn_SpatialBatchNormalization_transposeOutput(state, transposedOutput, output, nBatch, nFeature, nSpatial);
+
+   return;
+}
+
+static int cunn_SpatialBatchNormalization_updateOutputAffine(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 3);
+   int nFeature = (int)luaL_checknumber(L, 4);
+   int nSpatial = (int)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
+
+   // Pre-allocated buffers for the transposes
+   THCudaTensor *transposedInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+   THCudaTensor *transposedOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedOutput", "torch.CudaTensor");
+
+   // Output
+   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
+
+   // Temp structure for nFeature x nSpatial (aggregated over batch)
+   THCudaTensor *batchAgg = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "batchAgg", "torch.CudaTensor");
+
+   float epsilon = (float)luaT_getfieldchecknumber(L, 1, "eps");
+   THCudaTensor *weight = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "weight", "torch.CudaTensor");
+   THCudaTensor *bias = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "bias", "torch.CudaTensor");
+   THCudaTensor *meanBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "meanBuffer", "torch.CudaTensor");
+   THCudaTensor *stdBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "stdBuffer", "torch.CudaTensor");
+   THCudaTensor *centered = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "centered", "torch.CudaTensor");
+   THCudaTensor *normalized = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "normalized", "torch.CudaTensor");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 10, transposedInput, transposedOutput, output, batchAgg,
+                                  weight, bias, meanBuffer, stdBuffer, centered, normalized));
+   luaL_argcheck(L, input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+
+   /* Compute stats */
+   cunn_SpatialBatchNormalization_updateOutputComputeStats(state, input, transposedInput, batchAgg, meanBuffer,
+                                                           stdBuffer, centered, normalized,
+                                                           nBatch, nFeature, nSpatial);
+
+   /* Parallelization same as for compute stats kernels above */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+     in: transposedInput, meanBuffer, stdBuffer, weight, bias
+     out: transposedOutput, centered (transposedInput[i] - mean), normalized (not multiplied by weight & bias)
+
+     Normalize the transposedInput based on statistics.
+
+     transposedOutput[globalIndex] = weight * (transposedInput[i] - mean) * std + bias
+   */
+   spatialBatchNormalization_normalizeAffine_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedInput),
+                                                                                     THCudaTensor_data(state, meanBuffer),
+                                                                                     THCudaTensor_data(state, stdBuffer),
+                                                                                     THCudaTensor_data(state, transposedOutput),
+                                                                                     THCudaTensor_data(state, weight),
+                                                                                     THCudaTensor_data(state, bias),
+                                                                                     THCudaTensor_data(state, centered),
+                                                                                     THCudaTensor_data(state, normalized),
+                                                                                     epsilon, nBatch, nFeature, nSpatial,
+                                                                                     chunkSize);
+   /* Do final division by nBatch and tranpose output */
+   cunn_SpatialBatchNormalization_updateOutputNormStatsAndTranspose(state, transposedOutput, output, meanBuffer, stdBuffer,
+                                                                    epsilon, nBatch, nFeature, nSpatial);
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+
+static int cunn_SpatialBatchNormalization_updateOutput(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 3);
+   int nFeature = (int)luaL_checknumber(L, 4);
+   int nSpatial = (int)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *input = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
+
+   // Pre-allocated buffers for the transposes
+   THCudaTensor *transposedInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+   THCudaTensor *transposedOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedOutput", "torch.CudaTensor");
+
+   // Output
+   THCudaTensor *output = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "output", "torch.CudaTensor");
+
+   // Temp structure for nFeature x nSpatial (aggregated over batch)
+   THCudaTensor *batchAgg = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "batchAgg", "torch.CudaTensor");
+
+   float epsilon = (float)luaT_getfieldchecknumber(L, 1, "eps");
+   THCudaTensor *meanBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "meanBuffer", "torch.CudaTensor");
+   THCudaTensor *stdBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "stdBuffer", "torch.CudaTensor");
+   THCudaTensor *centered = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "centered", "torch.CudaTensor");
+   THCudaTensor *normalized = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "normalized", "torch.CudaTensor");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 8, transposedInput, transposedOutput, output, batchAgg,
+                                  meanBuffer, stdBuffer, centered, normalized));
+   luaL_argcheck(L, input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+
+   /* Compute stats */
+   cunn_SpatialBatchNormalization_updateOutputComputeStats(state, input, transposedInput, batchAgg, meanBuffer,
+                                                           stdBuffer, centered, normalized,
+                                                           nBatch, nFeature, nSpatial);
+
+   /* Parallelization same as for compute stats kernels above */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+     in: transposedInput, meanBuffer, stdBuffer
+     out: transposedOutput, centered (transposedInput[i] - mean), normalized
+
+     Normalize the transposedInput based on statistics.
+
+     transposedOutput[globalIndex] = (transposedInput[i] - mean) * std
+   */
+   spatialBatchNormalization_normalizeNoAffine_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedInput),
+                                                                                       THCudaTensor_data(state, meanBuffer),
+                                                                                       THCudaTensor_data(state, stdBuffer),
+                                                                                       THCudaTensor_data(state, transposedOutput),
+                                                                                       THCudaTensor_data(state, centered),
+                                                                                       THCudaTensor_data(state, normalized),
+                                                                                       epsilon, nBatch, nFeature, nSpatial,
+                                                                                       chunkSize);
+
+   /* Do final division by nBatch and tranpose output */
+   cunn_SpatialBatchNormalization_updateOutputNormStatsAndTranspose(state, transposedOutput, output, meanBuffer, stdBuffer,
+                                                                    epsilon, nBatch, nFeature, nSpatial);
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+
+static void cunn_SpatialBatchNormalization_updateGradInputComputeStats(THCState *state,
+                                                                       THCudaTensor *gradOutput,
+                                                                       THCudaTensor *transposedGradOutput,
+                                                                       THCudaTensor *transposedGradInput,
+                                                                       THCudaTensor *centered,
+                                                                       THCudaTensor *batchAgg,
+                                                                       THCudaTensor *meanBuffer,
+                                                                       THCudaTensor *stdBuffer,
+                                                                       int nBatch, int nFeature,
+                                                                       int nSpatial) {
+   /* Transpose input */
+   cunn_SpatialBatchNormalization_transposeInput(state, gradOutput, transposedGradOutput, nBatch, nFeature, nSpatial);
+
+   /*
+    -----
+    Block/thread dimensions for [nBatch x nFeature x nSpatial]
+    -----
+    blockIdx.x - gets a chunk of nSpatial dimension, depending on MAX_THREADS and the nBatch paramter.
+                 That is, each blockIdx.x handles as many nSpatial features as fits in its MAX_TREADS.
+                 If nBatch < 32, zero-pad to 32 so that one warp handles all batches in one spatial dim.
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nBatch dimension
+
+    For reductions, each block performs a local reduction of its values, across all the warps that span
+    the nBatch dimension. It then writes out the reduced (and normalized by nBatch) value to output[blockIdx.y].
+   */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+    -----
+    Block/thread dimensions for [nFeature x nSpatial]
+    -----
+    blockIdx.x - chunk of nSpatial dimension (chunk size bound by MAX_THREADS)
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nSpatial dimension
+
+    In reduction, first all blocks do a local reduction of their chunk, then we reduce across blocks
+    using atomic operations.
+   */
+   int spatialBlocks = getNumSpatialBlocks(nSpatial);
+
+   dim3 dimBlockSpatial(MAX_THREADS, 1);
+   dim3 dimGridSpatial(spatialBlocks, nFeature);
+
+
+   /*
+     in: centered, transposedGradOutput
+     out: transposedGradInput
+
+     Element-wise mulitply centered by transposedGradOutput, write out to transposedGradInput.
+   */
+   spatialBatchNormalization_elementWiseMultiply_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, centered),
+                                                                                         THCudaTensor_data(state, transposedGradOutput),
+                                                                                         THCudaTensor_data(state, transposedGradInput),
+                                                                                         nBatch, nFeature, nSpatial, chunkSize);
+   /*
+     in: transposedGradInput
+     out: batchAgg
+
+     Compute mean across nBatch dimension of transposedGradInput.
+   */
+   spatialBatchNormalization_batchMean_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedGradInput),
+                                                                               THCudaTensor_data(state, batchAgg),
+                                                                               nBatch, nFeature, nSpatial, chunkSize,
+                                                                               true);
+   /*
+     in: batchAgg
+     out: meanBuffer
+
+     Compute *sum* across nSpatial dimension of batchAgg. Normalize by nSpatial in kernel(s) below.
+   */
+   spatialBatchNormalization_spatialAgg_kernel<<<dimGridSpatial, dimBlockSpatial>>>(THCudaTensor_data(state, batchAgg),
+                                                                                    THCudaTensor_data(state, meanBuffer),
+                                                                                    nBatch, nFeature, nSpatial);
+   /*
+     in: centered, meanBuffer, stdBuffer (from forward pass)
+     out: transposedGradInput
+
+     transposedGradInput[i] = centered[i] * mean * -1 * std * std;
+   */
+   spatialBatchNormalization_normGradInput_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, centered),
+                                                                                   THCudaTensor_data(state, meanBuffer),
+                                                                                   THCudaTensor_data(state, stdBuffer),
+                                                                                   THCudaTensor_data(state, transposedGradInput),
+                                                                                   nBatch, nFeature, nSpatial, chunkSize);
+   /*
+     in: transposedGradOutput
+     out: batchAgg
+
+     Compute mean across nBatch dimension of transposedGradOutput.
+   */
+   spatialBatchNormalization_batchMean_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedGradOutput),
+                                                                               THCudaTensor_data(state, batchAgg),
+                                                                               nBatch, nFeature, nSpatial,
+                                                                               chunkSize, true);
+   /*
+     in: batchAgg
+     out: meanBuffer
+
+     Compute *sum* across nSpatial dimension of batchAgg. Normalize by nSpatial in kernel(s) below.
+   */
+   spatialBatchNormalization_spatialAgg_kernel<<<dimGridSpatial, dimBlockSpatial>>>(THCudaTensor_data(state, batchAgg),
+                                                                                    THCudaTensor_data(state, meanBuffer),
+                                                                                    nBatch, nFeature, nSpatial);
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return;
+}
+
+static int cunn_SpatialBatchNormalization_updateGradInputAffine(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 3);
+   int nFeature = (int)luaL_checknumber(L, 4);
+   int nSpatial = (int)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *gradOutput = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
+
+   // Pre-allocated buffers for the transposes, reused across forward/backward
+   THCudaTensor *transposedGradOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+   THCudaTensor *transposedGradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedOutput", "torch.CudaTensor");
+
+   // Output
+   THCudaTensor *gradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradInput", "torch.CudaTensor");
+
+   THCudaTensor *batchAgg = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "batchAgg", "torch.CudaTensor");
+   THCudaTensor *weight = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "weight", "torch.CudaTensor");
+   THCudaTensor *centered = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "centered", "torch.CudaTensor");
+   THCudaTensor *meanBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "meanBuffer", "torch.CudaTensor");
+   THCudaTensor *stdBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "stdBuffer", "torch.CudaTensor");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 7, batchAgg, gradOutput, gradInput, weight, centered, meanBuffer, stdBuffer));
+   luaL_argcheck(L, gradOutput->nDimension == 3 || gradOutput->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+   luaL_argcheck(L, gradInput->nDimension == 3 || gradInput->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+
+   cunn_SpatialBatchNormalization_updateGradInputComputeStats(state, gradOutput, transposedGradOutput, transposedGradInput,
+                                                              centered, batchAgg, meanBuffer, stdBuffer, nBatch, nFeature, nSpatial);
+
+   /* Parallelization same as for compute stats kernels above */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+   /*
+     in: transposedGradOutput, transposedGradInput, meanBuffer, stdBuffer, weight
+     out: transposedGradInput
+
+      transposedGradInput[i] = (transposedGradInput[i] + transposedGradOutput[i] - mean) * std * weight
+    */
+   spatialBatchNormalization_updateFinalGradInputAffine_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedGradOutput),
+                                                                                                THCudaTensor_data(state, transposedGradInput),
+                                                                                                THCudaTensor_data(state, meanBuffer),
+                                                                                                THCudaTensor_data(state, stdBuffer),
+                                                                                                THCudaTensor_data(state, weight),
+                                                                                                nBatch, nFeature, nSpatial, chunkSize);
+   /* Transpose output back */
+   cunn_SpatialBatchNormalization_transposeOutput(state, transposedGradInput, gradInput, nBatch, nFeature, nSpatial);
+
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+
+static int cunn_SpatialBatchNormalization_updateGradInput(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 3);
+   int nFeature = (int)luaL_checknumber(L, 4);
+   int nSpatial = (int)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *gradOutput = (THCudaTensor*)luaT_checkudata(L, 2, "torch.CudaTensor");
+
+   // Pre-allocated buffers for the transposes, reused across forward/backward
+   THCudaTensor *transposedGradOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+   THCudaTensor *transposedGradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedOutput", "torch.CudaTensor");
+
+   // Output
+   THCudaTensor *gradInput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradInput", "torch.CudaTensor");
+
+   THCudaTensor *batchAgg = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "batchAgg", "torch.CudaTensor");
+   THCudaTensor *centered = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "centered", "torch.CudaTensor");
+   THCudaTensor *meanBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "meanBuffer", "torch.CudaTensor");
+   THCudaTensor *stdBuffer = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "stdBuffer", "torch.CudaTensor");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 6, batchAgg, gradOutput, gradInput, centered, meanBuffer, stdBuffer));
+   luaL_argcheck(L, gradOutput->nDimension == 3 || gradOutput->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+   luaL_argcheck(L, gradInput->nDimension == 3 || gradInput->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+
+   cunn_SpatialBatchNormalization_updateGradInputComputeStats(state, gradOutput, transposedGradOutput, transposedGradInput,
+                                                              centered, batchAgg, meanBuffer, stdBuffer, nBatch, nFeature, nSpatial);
+
+   /* Parallelization same as for compute stats kernels above */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+     in: transposedGradOutput, transposedGradInput, meanBuffer, stdBuffer, weight
+     out: transposedGradInput
+
+      transposedGradInput[i] = (transposedGradInput[i] + transposedGradOutput[i] - mean) * std * weight
+    */
+   spatialBatchNormalization_updateFinalGradInputNoAffine_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, transposedGradOutput),
+                                                                                                  THCudaTensor_data(state, transposedGradInput),
+                                                                                                  THCudaTensor_data(state, meanBuffer),
+                                                                                                  THCudaTensor_data(state, stdBuffer),
+                                                                                                  nBatch, nFeature, nSpatial, chunkSize);
+   /* Transpose output back */
+   cunn_SpatialBatchNormalization_transposeOutput(state, transposedGradInput, gradInput, nBatch, nFeature, nSpatial);
+
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+
+static int cunn_SpatialBatchNormalization_accGradParameters(lua_State *L)
+{
+   THCState *state = getCutorchState(L);
+
+   // Params:
+   int nBatch = (int)luaL_checknumber(L, 2);
+   int nFeature = (int)luaL_checknumber(L, 3);
+   int nSpatial = (int)luaL_checknumber(L, 4);
+   float scale = (float)luaL_checknumber(L, 5);
+
+   // Input
+   THCudaTensor *gradOutput = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "transposedInput", "torch.CudaTensor");
+
+   THCudaTensor *gradBias = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradBias", "torch.CudaTensor");
+   THCudaTensor *normalized = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "normalized", "torch.CudaTensor");
+   THCudaTensor *gradWeight = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "gradWeight", "torch.CudaTensor");
+
+   // here these two are just buffers for the aggregates sum for gradOutput * normalized and gradOutput
+   THCudaTensor *buffer1 = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "meanBuffer", "torch.CudaTensor");
+   THCudaTensor *buffer2 = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "stdBuffer", "torch.CudaTensor");
+
+   // Temp structure for nFeature x nSpatial (aggregated over batch)
+   THCudaTensor *batchAgg = (THCudaTensor*)luaT_getfieldcheckudata(L, 1, "batchAgg", "torch.CudaTensor");
+
+   // flag to indicate whether the forward pass was called before this call
+   bool forwardDone = (bool)luaT_getfieldcheckboolean(L, 1, "forwardDone");
+
+   // assert
+   THAssert(THCudaTensor_checkGPU(state, 7, gradOutput, gradBias, normalized, gradWeight, buffer1, buffer2, batchAgg));
+   luaL_argcheck(L, gradOutput->nDimension == 3 || gradOutput->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+   THAssert(forwardDone);
+
+   /*
+    -----
+    Block/thread dimensions for [nBatch x nFeature x nSpatial]
+    -----
+    blockIdx.x - gets a chunk of nSpatial dimension, depending on MAX_THREADS and the nBatch paramter.
+                 That is, each blockIdx.x handles as many nSpatial features as fits in its MAX_TREADS.
+                 If nBatch < 32, zero-pad to 32 so that one warp handles all batches in one spatial dim.
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nBatch dimension
+
+    For reductions, each block performs a local reduction of its values, across all the warps that span
+    the nBatch dimension. It then writes out the reduced (and normalized by nBatch) value to output[blockIdx.y].
+   */
+   int chunkSize = getSpatialChunkSize(nBatch, nSpatial);
+   int numSpatialBlocks = nSpatial/chunkSize;
+
+   dim3 dimBlockBatch(MAX_THREADS, 1);
+   dim3 dimGridBatch(numSpatialBlocks, nFeature);
+
+   /*
+    -----
+    Block/thread dimensions for [nFeature x nSpatial]
+    -----
+    blockIdx.x - chunk of nSpatial dimension (chunk size bound by MAX_THREADS)
+    blockIdx.y - over nFeature dimension
+    threadIdx.x - over nSpatial dimension
+
+    In reduction, first all blocks do a local reduction of their chunk, then we reduce across blocks
+    using atomic operations.
+   */
+   int spatialBlocks = getNumSpatialBlocks(nSpatial);
+
+   dim3 dimBlockSpatial(MAX_THREADS, 1);
+   dim3 dimGridSpatial(spatialBlocks, nFeature);
+
+   /*
+    -----
+    Block/thread dimensions for [nFeature]
+    -----
+    blockIdx.x - 2 blocks, id 0 for mean, 1 for std
+    threadIdx.x - over nFeature dimension
+   */
+   dim3 gridBlockMeanStd(nFeature);
+   dim3 dimGridMeanStd(2, 1);
+
+   /*
+     in: normalized, gradOutput
+     out: normalized
+
+     Element-wise multiply normalized by gradOutput, write out to normalized
+     Note: this overwrites the normalized buffer
+   */
+   spatialBatchNormalization_elementWiseMultiply_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, normalized),
+                                                                                         THCudaTensor_data(state, gradOutput),
+                                                                                         THCudaTensor_data(state, normalized),
+                                                                                         nBatch, nFeature, nSpatial, chunkSize);
+   /*
+     in: normalized
+     out: batchAgg
+
+     Compute *sum* across nBatch dimension of normalized (divideByNBatch = false)
+   */
+   spatialBatchNormalization_batchMean_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, normalized),
+                                                                               THCudaTensor_data(state, batchAgg),
+                                                                               nBatch, nFeature, nSpatial,
+                                                                               chunkSize, false);
+   /*
+     in: batchAgg
+     out: buffer1
+
+     Compute *sum* across nSpatial dimension of batchAgg. Normalize by nSpatial in kernel(s) below.
+   */
+   spatialBatchNormalization_spatialAgg_kernel<<<dimGridSpatial, dimBlockSpatial>>>(THCudaTensor_data(state, batchAgg),
+                                                                                    THCudaTensor_data(state, buffer1),
+                                                                                    nBatch, nFeature, nSpatial);
+   /*
+     in: gradOutput
+     out: batchAgg
+
+     Compute *sum* across nBatch dimension of gradOutput (divideByNBatch = false)
+   */
+   spatialBatchNormalization_batchMean_kernel<<<dimGridBatch, dimBlockBatch>>>(THCudaTensor_data(state, gradOutput),
+                                                                               THCudaTensor_data(state, batchAgg),
+                                                                               nBatch, nFeature, nSpatial,
+                                                                               chunkSize,
+                                                                               false);
+   /*
+     in: batchAgg
+     out: buffer2
+
+     Compute *sum* across nSpatial dimension of batchAgg. Normalize by nSpatial in kernel(s) below.
+   */
+   spatialBatchNormalization_spatialAgg_kernel<<<dimGridSpatial, dimBlockSpatial>>>(THCudaTensor_data(state, batchAgg),
+                                                                                    THCudaTensor_data(state, buffer2),
+                                                                                    nBatch, nFeature, nSpatial);
+   /*
+     in: gradWeight, buffer1, gradBias, buffer2
+     out: gradWeight, gradBias
+
+     Scales weight and bias.
+     weight[i] = weight[i] + buffer1[i] * scale;
+     bias[i] = bias[i] + buffer2[i] * scale;
+   */
+   spatialBatchNormalization_updateWeightBias_kernel<<<dimGridMeanStd, gridBlockMeanStd>>>(THCudaTensor_data(state, gradWeight),
+                                                                                           THCudaTensor_data(state, buffer1),
+                                                                                           THCudaTensor_data(state, gradBias),
+                                                                                           THCudaTensor_data(state, buffer2),
+                                                                                           scale, nFeature);
+   cudaError errcode = cudaGetLastError();
+   if(errcode != cudaSuccess)
+     THError(cudaGetErrorString(errcode));
+
+   return 1;
+}
+static const struct luaL_Reg cunn_SpatialBatchNormalization__ [] = {
+  {"SpatialBatchNormalization_updateOutputAffine", cunn_SpatialBatchNormalization_updateOutputAffine},
+  {"SpatialBatchNormalization_updateOutput", cunn_SpatialBatchNormalization_updateOutput},
+  {"SpatialBatchNormalization_updateGradInputAffine", cunn_SpatialBatchNormalization_updateGradInputAffine},
+  {"SpatialBatchNormalization_updateGradInput", cunn_SpatialBatchNormalization_updateGradInput},
+  {"SpatialBatchNormalization_accGradParameters", cunn_SpatialBatchNormalization_accGradParameters},
+  {"SpatialBatchNormalization_forwardInferenceAffine", cunn_SpatialBatchNormalization_forwardInferenceAffine},
+  {"SpatialBatchNormalization_forwardInference", cunn_SpatialBatchNormalization_forwardInference},
+  {NULL, NULL}
+};
+
+static void cunn_SpatialBatchNormalization_init(lua_State *L)
+{
+  luaT_pushmetatable(L, "torch.CudaTensor");
+  luaT_registeratname(L, cunn_SpatialBatchNormalization__, "nn");
+  lua_pop(L,1);
+}

--- a/SpatialBatchNormalization.cuh
+++ b/SpatialBatchNormalization.cuh
@@ -1,0 +1,513 @@
+#ifndef __SBN_CUH__
+#define __SBN_CUH__
+
+#define MAX_THREADS 1024
+#define MAX_CHUNK_SIZE 256
+
+/*
+  Optimized reductions based on
+  http://devblogs.nvidia.com/parallelforall/faster-parallel-reductions-kepler/
+*/
+
+__inline__ __device__
+float warpReduceSum(float val, int width) {
+  int lane = threadIdx.x % warpSize;
+
+  float ret_val;
+  for (unsigned int offset = warpSize/2; offset > 0; offset /= 2) {
+    ret_val = __shfl_down(val, offset, width);
+    val = lane + offset < width ? val + ret_val : val;
+  }
+  return val;
+}
+
+__inline__ __device__
+void multiWarpReduceSum(float val, int width, int numValsToReduce,
+                        int chunkSize, float* reducedChunkVals) {
+
+  static __shared__ float shared[32][MAX_CHUNK_SIZE];
+
+  int lane = threadIdx.x % warpSize;
+  int wid = threadIdx.x / warpSize;
+
+  int mySpatialId = threadIdx.x / numValsToReduce;
+
+  val = warpReduceSum(val, width);
+
+  // special case here, one warp doing multiple spatial reductions
+  // write reduced value to shared memory for each chunk
+  if(lane == 0) {
+     shared[wid][mySpatialId] = val;
+  }
+  __syncthreads();
+
+  // at least one warp (for number of vals to reduce < warpSize)
+  int warpsInReduction = numValsToReduce/warpSize == 0 ? 1 : numValsToReduce/warpSize;
+  bool isEdgeWarp = (wid % warpsInReduction == 0);
+
+  if(isEdgeWarp) {
+     val = ( lane < warpsInReduction ) ? shared[lane + wid][mySpatialId] : float(0);
+     val = warpReduceSum(val, width);
+
+     if(lane == 0) {
+        reducedChunkVals[mySpatialId] = val;
+     }
+  }
+  return;
+}
+
+__inline__ __device__
+float blockReduceSum(float val, int width, int numThreads) {
+  static __shared__ float shared[32];
+  int lane = threadIdx.x%warpSize;
+  int wid = threadIdx.x/warpSize;
+  int warpsInReduction = numThreads/warpSize;
+  val = warpReduceSum(val, width);
+
+  __syncthreads();
+
+  //write reduced value to shared memory
+  if(lane==0) {
+    shared[wid] = val;
+  }
+  __syncthreads();
+
+  if (numThreads / warpSize == 0) {// special case if number of threads < warp size
+    val = shared[wid]; // one warp, already reduced
+  } else {
+    //ensure we only grab a value from shared memory if that warp existed
+    if(wid == 0) {
+      val = (lane < warpsInReduction) ? shared[lane] : float(0);
+      val = warpReduceSum(val, width);
+    }
+  }
+  return val;
+}
+
+/*
+  Computes either the sum or mean (divides the sum by nBatch) if divideByNBatch = true
+  across the batch dimension.
+*/
+__global__ void spatialBatchNormalization_batchMean_kernel(float* input, float* mean_output,
+                                                           int nBatch, int nFeature, int nSpatial,
+                                                           int chunkSize, bool divideByNBatch) {
+   int tid = threadIdx.x;
+
+   __shared__ float reducedChunkVals[MAX_CHUNK_SIZE];
+   int lane = tid % warpSize;
+   int wid = tid / warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsToReduce = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalInputIndex = blockIdx.y * nBatch * nSpatial + (blockIdx.x * nBatch * chunkSize) +
+                          (lane + wid * width);
+   int globalOutputIndex = blockIdx.y * nSpatial + blockIdx.x * chunkSize;
+
+   // if nBatch < 32, need to pad with 0 all elements that are > nBatch
+   float sum = lane < nBatch && globalInputIndex < nBatch * nFeature * nSpatial ? input[globalInputIndex] : 0.0f;
+
+   multiWarpReduceSum(sum, width, numValsToReduce, chunkSize, reducedChunkVals);
+
+   __syncthreads();
+
+   if (tid < chunkSize) {
+      // normalize if divideByNBatch is true
+      float res = divideByNBatch ? reducedChunkVals[tid] * 1.0f / (float)nBatch : reducedChunkVals[tid];
+
+      // write out to output
+      mean_output[globalOutputIndex + tid] = res;
+   }
+}
+
+__global__ void spatialBatchNormalization_spatialAgg_kernel(float* input, float* output,
+                                                            int nBatch, int nFeature,
+                                                            int nSpatial) {
+   int globalTid = blockIdx.x * blockDim.x + threadIdx.x;
+
+   int globalInputIndex = globalTid + blockIdx.y * nSpatial;
+   int globalOutputIndex = blockIdx.y;
+
+   // init accumulators to 0.0f
+   if (threadIdx.x == 0) {
+      if (blockIdx.x == 0) {
+         output[globalOutputIndex] = 0.0f;
+      }
+   }
+   __syncthreads();
+
+   float sum = 0.0f;
+
+   if (globalTid < nSpatial) {
+      sum = input[globalInputIndex];
+      int width = (nSpatial < warpSize) ? nSpatial : warpSize;
+      sum = blockReduceSum(sum, width, nSpatial);
+   }
+   __syncthreads();
+
+   if (threadIdx.x == 0) {
+      float ret = atomicAdd(&(output[globalOutputIndex]), sum);
+   }
+}
+
+__global__ void spatialBatchNormalization_batchVar_kernel(float* input, float* mean,
+                                                          float *std,
+                                                          int nBatch, int nFeature,
+                                                          int nSpatial, int chunkSize) {
+   __shared__ float reducedChunkVals[MAX_CHUNK_SIZE];
+
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsToReduce = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalInputIndex = blockIdx.y * nBatch * nSpatial +
+                          (blockIdx.x * nBatch * chunkSize) + (lane + wid * width);
+   int globalOutputIndex = blockIdx.y * nSpatial + blockIdx.x * chunkSize;
+   int nFeatureIndex = blockIdx.y;
+
+   float diff = lane < nBatch && globalInputIndex < nBatch * nFeature * nSpatial ? input[globalInputIndex] - mean[nFeatureIndex] * (1.0f/(float)nSpatial) : 0.0f;
+   float sum = diff * diff;
+
+   multiWarpReduceSum(sum, width, numValsToReduce, chunkSize, reducedChunkVals);
+
+   __syncthreads();
+
+   if (tid < chunkSize) {
+      // normalize
+      float res = reducedChunkVals[tid] * 1.0f / (float)nBatch;
+
+      // write out to output
+      std[globalOutputIndex + tid] = res;
+   }
+}
+
+__global__ void spatialBatchNormalization_normalizeAffine_kernel(float* input, float* mean,
+                                                                 float *std, float *output,
+                                                                 float* gamma, float* beta,
+                                                                 float* centered,
+                                                                 float* normalized,
+                                                                 float epsilon,
+                                                                 int nBatch, int nFeature,
+                                                                 int nSpatial, int chunkSize) {
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsInWarp = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   int nFeatureIndex = blockIdx.y;
+
+   // read ormalized mean & unnormalized std & normalize it locally
+   __shared__ float localNormStd;
+   __shared__ float localNormMean;
+
+   if (tid == 0) {
+      float normStd = std[nFeatureIndex] * (1.0f/(float)nSpatial);
+      localNormStd = 1.0f / sqrt(normStd + epsilon);
+      localNormMean = mean[nFeatureIndex] * 1.0f / (float)nSpatial;
+   }
+   __syncthreads();
+
+   // compute final normalized value
+   if (lane < nBatch && tid < numValsInWarp * chunkSize) {
+      float diff = input[globalIndex] - localNormMean;
+      // write out the centered data for use in updateGradInput
+      centered[globalIndex] = diff;
+      normalized[globalIndex] = diff * localNormStd;
+      output[globalIndex] = gamma[nFeatureIndex] *  diff * localNormStd + beta[nFeatureIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_normalizeNoAffine_kernel(float* input, float* mean,
+                                                                   float *std, float *output,
+                                                                   float* centered,
+                                                                   float* normalized,
+                                                                   float epsilon,
+                                                                   int nBatch, int nFeature,
+                                                                   int nSpatial, int chunkSize) {
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsInWarp = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   int nFeatureIndex = blockIdx.y;
+
+   // read ormalized mean & unnormalized std & normalize it locally
+   __shared__ float localNormStd;
+   __shared__ float localNormMean;
+
+   if (tid == 0) {
+      float normStd = std[nFeatureIndex] * (1.0f/(float)nSpatial);
+      localNormStd = 1.0f / sqrt(normStd + epsilon);
+      localNormMean = mean[nFeatureIndex] * 1.0f / (float)nSpatial;
+   }
+   __syncthreads();
+
+   // compute final normalized value
+   if (lane < nBatch && tid < numValsInWarp * chunkSize) {
+      float diff = input[globalIndex] - localNormMean;
+      // write out the centered data for use in updateGradInput
+      centered[globalIndex] = diff;
+      normalized[globalIndex] = diff * localNormStd;
+      output[globalIndex] = diff * localNormStd;
+   }
+}
+
+__global__ void spatialBatchNormalization_normalizeForwardInfAffine_kernel(float* input,
+                                                                           float* mean, float *std,
+                                                                           float *weight, float *bias,
+                                                                           float *output,
+                                                                           int nBatch, int nFeature,
+                                                                           int nSpatial, int chunkSize) {
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsInWarp = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   int nFeatureIndex = blockIdx.y;
+
+   // compute normalized value
+   if (lane < nBatch && tid < numValsInWarp * chunkSize) {
+      output[globalIndex] =
+         weight[nFeatureIndex] * (input[globalIndex] - mean[nFeatureIndex]) * std[nFeatureIndex] + bias[nFeatureIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_normalizeForwardInfNoAffine_kernel(float* input,
+                                                                            float* mean, float *std,
+                                                                            float *output,
+                                                                            int nBatch, int nFeature,
+                                                                            int nSpatial, int chunkSize) {
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsInWarp = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   int nFeatureIndex = blockIdx.y;
+
+   // compute normalized value
+   if (lane < nBatch && tid < numValsInWarp * chunkSize) {
+      output[globalIndex] = (input[globalIndex] - mean[nFeatureIndex]) * std[nFeatureIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_normalizeForwardInf_kernel(float* input,
+                                                                     float* mean, float *std,
+                                                                     float *output,
+                                                                     int nBatch, int nFeature,
+                                                                     int nSpatial, int chunkSize) {
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsInWarp = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   int nFeatureIndex = blockIdx.y;
+
+   // compute normalized value
+   if (lane < nBatch && tid < numValsInWarp * chunkSize) {
+      output[globalIndex] = (input[globalIndex] - mean[nFeatureIndex]) * std[nFeatureIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_normalizeMeanStd_kernel(float* mean, float* std,
+                                                                  float factor, float epsilon,
+                                                                  int nFeature) {
+   int tid = threadIdx.x;
+
+   if (tid < nFeature) {
+      if (blockIdx.x == 0) {
+         mean[tid] = mean[tid] * factor;
+      } else {
+         float nstd = std[tid] * factor;
+         std[tid] = 1.0f / sqrt(nstd + epsilon);
+      }
+   }
+}
+
+__global__ void spatialBatchNormalization_elementWiseMultiply_kernel(float* input1, float* input2,
+                                                                     float* output,
+                                                                     int nBatch, int nFeature,
+                                                                     int nSpatial, int chunkSize) {
+
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsToReduce = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   if (lane < nBatch && tid < numValsToReduce * chunkSize) {
+      output[globalIndex] = input1[globalIndex] * input2[globalIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_normGradInput_kernel(float* centered, float* mean,
+                                                               float *std,
+                                                               float* gradInput,
+                                                               int nBatch, int nFeature,
+                                                               int nSpatial,
+                                                               int chunkSize) {
+   __shared__ float localNormMean;
+   __shared__ float localStd;
+
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsToReduce = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+
+   int nFeatureIndex = blockIdx.y;
+
+   if (tid == 0) {
+      localStd = std[nFeatureIndex];
+      localNormMean = mean[nFeatureIndex] * (1.0f/(float)nSpatial);
+   }
+   __syncthreads();
+
+   if (lane < nBatch && tid < numValsToReduce * chunkSize) {
+      gradInput[globalIndex] = centered[globalIndex] * localNormMean * -1 * localStd * localStd;
+   }
+}
+
+__global__ void spatialBatchNormalization_updateFinalGradInputAffine_kernel(float* gradOutput, float* gradInput,
+                                                                            float* mean,
+                                                                            float* std,
+                                                                            float* weight,
+                                                                            int nBatch, int nFeature,
+                                                                            int nSpatial,
+                                                                            int chunkSize) {
+   __shared__ float localNormMean;
+
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsToReduce = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+   int nFeatureIndex = blockIdx.y;
+
+   if (tid == 0) {
+      localNormMean = mean[nFeatureIndex] * (1.0f/(float)nSpatial);
+   }
+   __syncthreads();
+
+   if (lane < nBatch && tid < numValsToReduce * chunkSize) {
+      gradInput[globalIndex] =
+        (gradInput[globalIndex] + gradOutput[globalIndex] - localNormMean) * std[nFeatureIndex] * weight[nFeatureIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_updateFinalGradInputNoAffine_kernel(float* gradOutput, float* gradInput,
+                                                                            float* mean,
+                                                                            float* std,
+                                                                            int nBatch, int nFeature,
+                                                                            int nSpatial,
+                                                                            int chunkSize) {
+   __shared__ float localNormMean;
+
+   int tid = threadIdx.x;
+   int lane = tid % warpSize;
+   int wid = tid/warpSize;
+   int width = (nBatch < warpSize) ? nBatch : warpSize;
+   int numValsToReduce = (nBatch < warpSize) ? warpSize : nBatch;
+
+   int globalIndex = blockIdx.y * nBatch * nSpatial +
+                     (blockIdx.x * nBatch * chunkSize) + (lane + wid*width);
+   int nFeatureIndex = blockIdx.y;
+
+   if (tid == 0) {
+      localNormMean = mean[nFeatureIndex] * (1.0f/(float)nSpatial);
+   }
+   __syncthreads();
+
+   if (lane < nBatch && tid < numValsToReduce * chunkSize) {
+      gradInput[globalIndex] =
+        (gradInput[globalIndex] + gradOutput[globalIndex] - localNormMean) * std[nFeatureIndex];
+   }
+}
+
+__global__ void spatialBatchNormalization_updateWeightBias_kernel(float* weight, float* w_update, float* bias,
+                                                                  float* b_update, float scale, int nFeature) {
+   int tid = threadIdx.x;
+
+   if (tid < nFeature) {
+      if (blockIdx.x == 0) {
+         weight[tid] = weight[tid] + w_update[tid] * scale;
+      } else {
+         bias[tid] = bias[tid] + b_update[tid] * scale;
+      }
+   }
+}
+
+/* Transpose kernels */
+__global__ void transposeInputClsdRead_kernel(float* in, float* transp, int nBatch, int nFeature, int nSpatial) {
+
+   int numValsInChunk = blockDim.x;
+   int totalSize = nBatch * nFeature * nSpatial;
+
+   int inputIndex = blockIdx.x * nFeature * nSpatial + blockIdx.y * nSpatial + blockIdx.z * numValsInChunk + threadIdx.x;
+   int outputIndex = blockIdx.y * nSpatial * nBatch + threadIdx.x * nBatch + blockIdx.z * nBatch * numValsInChunk + blockIdx.x;
+
+   if (outputIndex < totalSize && inputIndex < totalSize) {
+     transp[outputIndex] = in[inputIndex];
+   }
+}
+
+__global__ void transposeInputClsdWrite_kernel(float* in, float* transp, int nBatch, int nFeature, int nSpatial, int batchesInBlock) {
+
+   int totalSize = nBatch * nFeature * nSpatial;
+
+   int tidInBatch = threadIdx.x % nBatch;
+   int localSpatialIndex = threadIdx.x / nBatch;
+
+   int inputIndex = tidInBatch * nSpatial * nFeature + blockIdx.y * nSpatial + blockIdx.x * batchesInBlock + localSpatialIndex;
+   int outputIndex = blockIdx.y * nSpatial * nBatch + blockIdx.x * nBatch * batchesInBlock + threadIdx.x;
+
+   if (outputIndex < totalSize && inputIndex < totalSize) {
+     transp[outputIndex] = in[inputIndex];
+   }
+}
+
+__global__ void transposeOutput_kernel(float* transp, float* out, int nBatch, int nFeature, int nSpatial, int batchesInBlock) {
+
+   int totalSize = nBatch * nFeature * nSpatial;
+
+   int tidInBatch = threadIdx.x % nBatch;
+   int localSpatialIndex = threadIdx.x / nBatch;
+
+   int inputIndex = blockIdx.y * nSpatial * nBatch + blockIdx.x * nBatch * batchesInBlock + threadIdx.x;
+   int outputIndex = tidInBatch * nSpatial * nFeature + blockIdx.y * nSpatial + blockIdx.x * batchesInBlock + localSpatialIndex;
+
+   if (outputIndex < totalSize && inputIndex < totalSize) {
+     out[outputIndex] = transp[inputIndex];
+   }
+}
+
+#endif

--- a/init.cu
+++ b/init.cu
@@ -46,6 +46,7 @@ int luaopen_libcunn(lua_State *L)
   cunn_LogSigmoid_init(L);
   cunn_PReLU_init(L);
   cunn_LookupTable_init(L);
+  cunn_SpatialBatchNormalization_init(L);
 
   return 1;
 }

--- a/test.lua
+++ b/test.lua
@@ -3817,6 +3817,343 @@ function cunntest.LookupTable_backward()
    mytester:assertlt(weightGradError:abs():max(), precision_backward, 'error on weight')
 end
 
+function cunntest.SpatialBatchNormalization_evaluate_pow2()
+   local nBatch = 32
+   local nFeature = 16
+   local iH = 8
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization evaluate %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature)
+   sconv:evaluate()
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:evaluate()
+   local rescuda = gconv:forward(input)
+   cutorch.synchronize()
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+end
+
+function cunntest.SpatialBatchNormalization_evaluate_pow2_not_affine()
+   local nBatch = 32
+   local nFeature = 16
+   local iH = 8
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization evaluate %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature, eps, momentum, false)
+   sconv:evaluate()
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:evaluate()
+   local rescuda = gconv:forward(input)
+   cutorch.synchronize()
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+end
+
+-- test the optimized SBN forward path
+function cunntest.SpatialBatchNormalization_forward_pow2()
+   local nBatch = 32
+   local nFeature = 16
+   local iH = 8
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization forward %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature)
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+   local groundrunningmean = sconv.running_mean
+   local groundrunningstd = sconv.running_std
+
+   input = input:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:resetRunningStats(nFeature)
+   local rescuda = gconv:forward(input)
+   cutorch.synchronize()
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+   local cudarunningmean = gconv.running_mean
+   local cudarunningstd = gconv.running_std
+
+   local error = rescuda:float() - groundtruth
+   local rmeanerror = cudarunningmean:float() - groundrunningmean
+   local rstderror = cudarunningstd:float() - groundrunningstd
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+   mytester:assertlt(rmeanerror:abs():max(), precision_forward, 'error on running_mean (forward) ')
+   mytester:assertlt(rstderror:abs():max(), precision_forward, 'error on running_std (forward) ')
+end
+
+function cunntest.SpatialBatchNormalization_forward_pow2_not_affine()
+   local nBatch = 32
+   local nFeature = 16
+   local iH = 8
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization forward not affine %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature, eps, momentum, false)
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+   local groundrunningmean = sconv.running_mean
+   local groundrunningstd = sconv.running_std
+
+   input = input:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:resetRunningStats(nFeature)
+   local rescuda = gconv:forward(input)
+   cutorch.synchronize()
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+   local cudarunningmean = gconv.running_mean
+   local cudarunningstd = gconv.running_std
+
+   local error = rescuda:float() - groundtruth
+   local rmeanerror = cudarunningmean:float() - groundrunningmean
+   local rstderror = cudarunningstd:float() - groundrunningstd
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+   mytester:assertlt(rmeanerror:abs():max(), precision_forward, 'error on running_mean (forward) ')
+   mytester:assertlt(rstderror:abs():max(), precision_forward, 'error on running_std (forward) ')
+end
+
+-- test the optimized SBN backward path
+function cunntest.SpatialBatchNormalization_backward_pow2()
+   local nBatch = 32
+   local nFeature = 16
+   local iH = 8
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization backward %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local gradOutput = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature)
+   sconv:resetGradParams()
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local groundweight = sconv.gradWeight
+   local groundbias = sconv.gradBias
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:resetGradParams()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+   local weightcuda = gconv.gradWeight
+   local biascuda = gconv.gradBias
+
+   local error = rescuda:float() - groundgrad
+   local werror = weightcuda:float() - groundweight
+   local berror = biascuda:float() - groundbias
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+   mytester:assertlt(werror:abs():max(), precision_backward, 'error on weight (backward) ')
+   mytester:assertlt(berror:abs():max(), precision_backward, 'error on bias (backward) ')
+end
+
+function cunntest.SpatialBatchNormalization_backward_pow2_not_affine()
+   local nBatch = 32
+   local nFeature = 16
+   local iH = 8
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization backward not affine %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local gradOutput = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature, eps, momentum, false)
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local groundweight = sconv.gradWeight
+   local groundbias = sconv.gradBias
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
+function cunntest.SpatialBatchNormalization_forward()
+   local nBatch = math.random(1,100)
+   local nFeature = math.random(1,100)
+   local iH = math.random(1,100)
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization forward %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature)
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = sconv:clone():cuda()
+   local rescuda = gconv:forward(input)
+   cutorch.synchronize()
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward, 'error on state (forward) ')
+end
+
+function cunntest.SpatialBatchNormalization_backward()
+   local nBatch = math.random(1,100)
+   local nFeature = math.random(1,100)
+   local iH = math.random(1,100)
+   local iW = iH
+   local nSpatial = iH * iW
+
+   -- manual seed for consistent initialization
+   torch.manualSeed(1)
+   cutorch.manualSeedAll(1)
+
+   local tm = {}
+   local title = string.format('SpatialBatchNormalization backward %dx%d -> %dx%d', nFeature, nSpatial, nFeature, nSpatial)
+   times[title] = tm
+
+   local input = torch.randn(nBatch, nFeature, iH, iW)
+   local gradOutput = torch.randn(nBatch, nFeature, iH, iW)
+   local sconv = nn.SpatialBatchNormalization(nFeature)
+   sconv:resetGradParams()
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local groundweight = sconv.gradWeight
+   local groundbias = sconv.gradBias
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:resetGradParams()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+   local weightcuda = gconv.gradWeight
+   local biascuda = gconv.gradBias
+
+   local error = rescuda:float() - groundgrad
+   local werror = weightcuda:float() - groundweight
+   local berror = biascuda:float() - groundbias
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+   mytester:assertlt(werror:abs():max(), precision_backward, 'error on weight (backward) ')
+   mytester:assertlt(berror:abs():max(), precision_backward, 'error on bias (backward) ')
+end
+
 local function setUp()
    cutorch.setDevice(1)
 end

--- a/utils.h
+++ b/utils.h
@@ -40,6 +40,7 @@ void cunn_VolumetricAveragePooling_init(lua_State *L);
 void cunn_LogSigmoid_init(lua_State *L);
 void cunn_PReLU_init(lua_State *L);
 void cunn_LookupTable_init(lua_State *L);
+void cunn_SpatialBatchNormalization_init(lua_State *L);
 
 
 #endif


### PR DESCRIPTION
This patch adds GPU kernels and host functions for optimized spatial batch normalization routines. This gives up to 4x speedup in forward/backward, up to 6x in validation forward and total of up to 2x boost in overall model training performance compared to using the current batch normalization implementation. 

The new optimized path works for specific problem dimensions, for both affine and non-affine updates:
* batchSize <= 32 or power of 2 i.e. 64, 128, 256, 512, 1025
* nFeature <= 1024
* iH/iW powers of 2

It defaults to the original implementation if it doesn't support the problem dimensions. 

This patch is in conjunction to the SpatialBatchNormalization update in torch/nn/SpatialBatchNormalzation.lua.

Adds unit tests for all the new code paths.

cc @clementfarabet 