### PR TITLE
Allow move to CUDA from top-level module

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -210,7 +210,7 @@ function DataParallelTable:add(module, gpuid)
    assert(gpuid <= cutorch.getDeviceCount() and gpuid >= 1)
    assert(#self.modules == #self.gpuAssignments)
 
-   self.modules[#self.modules + 1] = module
+   self.modules[#self.modules + 1] = module:cuda()
    self.gpuAssignments[#self.gpuAssignments + 1] = gpuid
 
    return self
@@ -482,7 +482,7 @@ function DataParallelTable:name()
 end
 
 function DataParallelTable:type(typeStr)
-   error("type() not supported for DataParallelTable.")
+   assert(typeStr == 'torch.CudaTensor', "DataParallelTable supports only torch.CudaTensor type.")
 end
 
 function DataParallelTable:_calculateSliceRange(tensor, id, total)


### PR DESCRIPTION
Hi Guys, I am proposing this PR as I find the changes convenient for my project however I am unsure if that fits into the grand plan of things so I let the experts decide. Thanks!

Commit message:

When defining a network in Torch it is customary to move it
to the currently selected GPU through a single call to the
top-level module's cuda() method.

This patch allows this by merely asserting in the type()
method that the target type is 'torch.CudaTensor', rather
that dropping an error unconditionally.

In this patch we are also conveniently moving any added
module to CUDA, since it only makes sense to add CUDA
modules to a DataParallelTable container.