### PR TITLE
Add multi-threading support in DataParallelTable

### DIFF
--- a/doc/cunnmodules.md
+++ b/doc/cunnmodules.md
@@ -7,43 +7,59 @@ The following nn modules are also made available by the cunn package:
 <a name="nn.DataParallelTable"/>
 ## DataParallelTable ##
 
-This module makes splitting data across multiple GPUs easy and seamless. The API is based loosely on the fbcunn ```DataParallel``` module (hence the name), but support for nested table input and outputs has been added.
+```lua
+module = nn.DataParallelTable(dim, [flattenParams], [useNCCL])
+module:add(net, {gpu1, [gpu2, ...]})
+```
 
-Note that some of the code in this module borrows heavily from fbcunn (particularly ```asyncGPUCopy``` and ```getBuffer```), so credit also should go to Facebook for supplying the original starter code.  Usage:
+DataParallelTable implements data parallelism for Torch modules. The same model
+is replicated on multiple GPUs. The input is split, typically into smaller mini-batches.
+Each replicated model handles only its portion of the input. The weight updates for 
+each replica are summed together on the first replica in accGradParameters.
+
+### DataParallelTable(dim, [flattenParams], [useNCCL]) ###
+
+Creates a `DataParallelTable` that splits the input on the dimension `dim`. If `flattenParams` is `true`, [`getParameters()`](https://github.com/torch/nn/blob/master/doc/module.md#nn.Module.getParameters) will be called on the replicated module. If `useNCCL` is `true` and both [NCCL](https://github.com/NVIDIA/nccl) and the [NCCL torch bindings](https://github.com/ngimel/nccl.torch) are installed, NCCL will be used for inter-GPU communication.
+
+For best performance, use `flattenParams` and `NCCL`.
+
+### DataParallelTable:add(module, gpus) ###
+
+Replicates `module` on the table of `gpus`. For example:
+
+```lua
+nn.DataParallelTable(1):add(module, {1, 2, 3, 4})
+```
+
+### DataParallelTable:threads(initFunc) ###
+
+Switches the internal implementation to  use a seperate thread for each replica. This may hide the cost of kernel launches by dispatching them in parallel. The `initFunc` is executed in each thread.
+
+```lua
+nn.DataParallelTable(1):threads(function()
+  require 'cudnn'
+end)
+```
+
+### DataParallelTable:syncParameters() ###
+
+Copies the model parameters from the first replica to all other replicas. This is automatically called from `updateOutput`, if it has not been called since the last `accGradParameters`.
+
+### Example of training using DataParallelTable ###
 
 ```lua
 -- CONSTRUCT MODEL:
 conv_net = makeConvNet()  -- i.e. create nn.Sequential() and fill it
 net = nn.DataParallelTable(1)  -- Split along first (batch) dimension
-for i = 1, 2 do
-  cutorch.setDevice(i)
-  net:add(conv_net:clone():cuda(), i)  -- Use the ith GPU
-end
-cutorch.setDevice(1)  -- This is the 'primary' GPU
-parameters, gradParameters = net:getParameters()
+net:add(conv_net, {1, 2}) -- Use GPUs 1 and 2
 -- TRAINING:
 for i = 1, num_epochs do
-  feval = function(x)
-    net:zeroGradParameters()
-    local output = net:forward(input)
-    local err = criterion:forward(output, target)
-    local gradOutput = criterion:backward(output, target)
-    local gradInput = net:backward(input, gradOutput)
-    return err, gradParameters
-  end
-  optim.sgd(feval, parameters, optimState)
-  net:syncParameters()  -- **** NEW ADDITIONAL CALL ****
+  local output = net:forward(input)
+  local err = criterion:forward(output, target)
+  net:zeroGradParameters()
+  local gradOutput = criterion:backward(output, target)
+  local gradInput = net:backward(input, gradOutput)
+  net:updateParameters(lr)
 end
 ```
 
-To the outside world we make this module look like it just includes the parameters for the primary GPU (which is defined as the first module added by the ```:add()``` call), so that the optimizer can pretend it's one model on one GPU. Unfortunately we break the abstraction in one annoying way: every time you update the parameters you need to call ```:syncParameters()```, to distribute the new parameters to the other GPUs (this additional call is highlighted in the above usage example).
-
-There are still some limitations with this module:
- * weight sharing is not implemented and if you use models with shared weights it will likely break across GPUs.
- * accGradParameters and updateParameters functions are not implemented because optim doesn't use them.
-
-The differences between this module and fbcunn's ```DataParallel``` are:
- * ```DataParallel``` requires the use of nn.Optim (since it includes the ```_mixGrads``` call and because ```getParameters()``` is not implemented), whereas ```DataParallelTable``` allows the use of the optim package with closures.
- * The ```DataParallel``` instance must be the outer container, whereas ```DataParallelTable``` supports nesting within a larger network.
- * ```DataParallel``` requires tensor inputs and outputs, whereas ```DataParallelTable``` supports arbitrarily nested tables of tensors.
- * At the time of writing ```DataParallelTable``` is a little faster.


### PR DESCRIPTION
This lets us use the fastest CUDNN R4 kernels with DPT, which have much
higher launch overhead. With single-threaded dispatch, the launch
overhead from these kernels delays the second, third, and fourth GPUs so
much that it actually increases the total time.

I've also included some other optimizations:
- `gradInput` can be set to `nil` when the DataParallelTable is the
  top-level module; this saves time and memory
- input can optionally be on the CPU; this saves memory on the first
  GPU, and is faster when the input is in pinned memory since the copies
  to each GPU happen concurrently.

This change is mostly backwards compatible, with the below caveats:
- The preferred way to add modules is by a single call to add with the
  list of GPUs i.e. `:add(module, {1, 2, 3, 4})`
- `DataParallelTable:get()` only works with the first module

With these changes I'm able to realize a 20-25% speedup with MSRA's ResNet model on 4 GPUs, mostly because it allows the use of the fastest CUDNN R4 kernels.

@dominikgrewe, if you have time, your review would be appreciated