### PR TITLE
Instantiate impl field in older models

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -324,6 +324,7 @@ function DataParallelTable:__read(file, version)
       for k, v in pairs(var) do
          self[k] = v
       end
+      self.impl = self.impl or Impls.Basic(self)
       return
    end
 


### PR DESCRIPTION
Currently, when an old model checkpoint is loaded, it's `impl` field isn't initialized, so it crashes as soon as you try to do anything with the network.