### PR TITLE
Fixed VolumetricFullConvolution.

### DIFF
--- a/THCUNN.lua
+++ b/THCUNN.lua
@@ -730,7 +730,8 @@ TH_API void THNN_CudaVolumetricFullConvolution_updateOutput(
           THCudaTensor *finput,
           THCudaTensor *fgradInput,
           int dT, int dW, int dH,
-          int pT, int pW, int pH);
+          int padT, int padW, int padH,
+          int adjT, int adjW, int adjH);
 TH_API void THNN_CudaVolumetricFullConvolution_updateGradInput(
           THCState *state,
           THCudaTensor *input,
@@ -740,7 +741,8 @@ TH_API void THNN_CudaVolumetricFullConvolution_updateGradInput(
           THCudaTensor *finput,
           THCudaTensor *fgradInput,
           int dT, int dW, int dH,
-          int pT, int pW, int pH);
+          int padT, int padW, int padH,
+          int adjT, int adjW, int adjH);
 TH_API void THNN_CudaVolumetricFullConvolution_accGradParameters(
           THCState *state,
           THCudaTensor *input,
@@ -750,7 +752,8 @@ TH_API void THNN_CudaVolumetricFullConvolution_accGradParameters(
           THCudaTensor *finput,
           THCudaTensor *fgradInput,
           int dT, int dW, int dH,
-          int pT, int pW, int pH,
+          int padT, int padW, int padH,
+          int adjT, int adjW, int adjH,
           float scale);
 
 TH_API void THNN_CudaVolumetricMaxPooling_updateOutput(

--- a/lib/THCUNN/THCUNN.h
+++ b/lib/THCUNN/THCUNN.h
@@ -722,7 +722,8 @@ TH_API void THNN_CudaVolumetricFullConvolution_updateOutput(
           THCudaTensor *finput,
           THCudaTensor *fgradInput,
           int dT, int dW, int dH,
-          int pT, int pW, int pH);
+          int padT, int padW, int padH,
+          int adjT, int adjW, int adjH);
 TH_API void THNN_CudaVolumetricFullConvolution_updateGradInput(
           THCState *state,
           THCudaTensor *input,
@@ -732,7 +733,8 @@ TH_API void THNN_CudaVolumetricFullConvolution_updateGradInput(
           THCudaTensor *finput,
           THCudaTensor *fgradInput,
           int dT, int dW, int dH,
-          int pT, int pW, int pH);
+          int padT, int padW, int padH,
+          int adjT, int adjW, int adjH);
 TH_API void THNN_CudaVolumetricFullConvolution_accGradParameters(
           THCState *state,
           THCudaTensor *input,
@@ -742,7 +744,8 @@ TH_API void THNN_CudaVolumetricFullConvolution_accGradParameters(
           THCudaTensor *finput,
           THCudaTensor *fgradInput,
           int dT, int dW, int dH,
-          int pT, int pW, int pH,
+          int padT, int padW, int padH,
+          int adjT, int adjW, int adjH,
           float scale);
 
 TH_API void THNN_CudaVolumetricMaxPooling_updateOutput(

--- a/lib/THCUNN/VolumetricFullConvolution.cu
+++ b/lib/THCUNN/VolumetricFullConvolution.cu
@@ -1,204 +1,63 @@
 #include "THCUNN.h"
-#include "common.h"
+#include "vol2col.h"
 
-#define CUDA_KERNEL_LOOP(i, n) \
-for (int i = blockIdx.x * blockDim.x + threadIdx.x; \
-  i < (n); \
-  i += blockDim.x * gridDim.x)
-
-#define CUDA_CHECK(condition) \
-/* Code block avoids redefinition of cudaError_t error */ \
- do { \
-   cudaError_t error = condition; \
-   THArgCheck(error == cudaSuccess, 2, cudaGetErrorString(error)); \
- } while (0)
-
-template <typename Dtype>
-__global__ void vol2col_kernel(const int n, const Dtype* data_im,
-    const int length, const int height, const int width,
-    const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride,
-    const int length_col, const int height_col, const int width_col,
-    Dtype* data_col)
-{
-  CUDA_KERNEL_LOOP(index, n)
-  {
-    int w_out = index % width_col;
-    int h_out = (index / width_col ) % height_col;
-    int l_out = (index / width_col / height_col) % length_col;
-    int channel_in = index / width_col / height_col / length_col;
-    int channel_out = channel_in * kdepth * ksize * ksize;
-    int h_in = h_out * stride - pad;
-    int w_in = w_out * stride - pad;
-    int l_in = l_out * temporal_stride - temporal_pad;
-
-    data_col += ((channel_out * length_col + l_out) * height_col + h_out) * width_col + w_out;
-    data_im += ((channel_in * length + l_in) * height + h_in) * width + w_in;
-    for (int k = 0; k < kdepth; ++k)
-    {
-      for (int i = 0; i < ksize; ++i)
-      {
-        for (int j = 0; j < ksize; ++j)
-        {
-          int l = l_in + k;
-          int h = h_in + i;
-          int w = w_in + j;
-          *data_col = (l >= 0 && h >= 0 && w >= 0 && h < height && w < width && l < length) ?
-              data_im[(k * height + i) * width + j] : 0;
-          data_col += length_col * height_col * width_col;
-        }
-      }
-    }
-  }
-}
-
-template <typename Dtype>
-void vol2col(const Dtype* data_im, const int channels, const int length,
-    const int height, const int width, const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride, Dtype* data_col)
-{
-
-  int length_col = (length + 2 * temporal_pad - kdepth) / temporal_stride + 1;
-  int height_col = (height + 2 * pad - ksize) / stride + 1;
-  int width_col = (width + 2 * pad - ksize) / stride + 1;
-  int num_kernels = channels * length_col * height_col * width_col;
-
-  vol2col_kernel<Dtype><<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
-      num_kernels, data_im, length, height, width, ksize, kdepth, pad, temporal_pad, stride, temporal_stride,
-      length_col, height_col, width_col, data_col);
-
-}
-
-// Explicit instantiation
-template void vol2col<float>(const float* data_im, const int channels, const int length,
-    const int height, const int width, const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride, float* data_col);
-template void vol2col<double>(const double* data_im, const int channels, const int length,
-    const int height, const int width, const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride, double* data_col);
-
-template <typename Dtype>
-__global__ void col2vol_kernel(const int n, const Dtype* data_col,
-    const int length, const int height, const int width, const int channels,
-    const int ksize, const int kdepth,
-    const int pad, const int temporal_pad, const int stride, const int temporal_stride,
-    const int length_col, const int height_col, const int width_col,
-    Dtype* data_im)
-{
-  CUDA_KERNEL_LOOP(index, n)
-  {
-    Dtype val = 0;
-    int w = index % width + pad;
-    int h = (index / width) % height + pad;
-    int l = (index / width / height) % length + temporal_pad;
-    int c = index / (width * height * length);
-    // compute the start and end of the output
-    int w_col_start = (w < ksize) ? 0 : (w - ksize) / stride + 1;
-    int w_col_end = min(w / stride + 1, width_col);
-    int h_col_start = (h < ksize) ? 0 : (h - ksize) / stride + 1;
-    int h_col_end = min(h / stride + 1, height_col);
-    int l_col_start = (l < kdepth) ? 0 : (l - kdepth) / temporal_stride + 1;
-    int l_col_end = min(l / temporal_stride + 1, length_col);
-
-    int offset = (c * kdepth * ksize * ksize + l * ksize * ksize + h * ksize + w) * length_col * height_col * width_col;
-
-    int coeff_l_col = (1 - temporal_stride * ksize * ksize * length_col) * height_col * width_col;
-    int coeff_h_col = (1 - stride * ksize * length_col * height_col) * width_col;
-    int coeff_w_col = (1 - stride * length_col * height_col * width_col);
-
-    for (int l_col = l_col_start; l_col < l_col_end; ++l_col) {
-      for (int h_col = h_col_start; h_col < h_col_end; ++h_col) {
-        for (int w_col = w_col_start; w_col < w_col_end; ++w_col) {
-          val += data_col[offset + l_col * coeff_l_col + h_col * coeff_h_col + w_col * coeff_w_col];
-        }
-      }
-    }
-    data_im[index] = val;
-  }
-}
-
-template <typename Dtype>
-void col2vol(const Dtype* data_col, const int channels, const int length,
-    const int height, const int width, const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride, Dtype* data_im)
-{
-  int length_col = (length + 2 * temporal_pad - kdepth) / temporal_stride + 1;
-  int height_col = (height + 2 * pad - ksize) / stride + 1;
-  int width_col = (width + 2 * pad - ksize) / stride + 1;
-  int num_kernels = channels * length * height * width;
-
-  col2vol_kernel<Dtype><<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
-      num_kernels, data_col, length, height, width, channels, ksize, kdepth, pad, temporal_pad, stride, temporal_stride,
-      length_col, height_col, width_col, data_im);
-}
-
-// Explicit instantiation
-template void col2vol<float>(const float* data_col, const int channels, const int length,
-    const int height, const int width, const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride, float* data_im);
-template void col2vol<double>(const double* data_col, const int channels, const int length,
-    const int height, const int width, const int ksize, const int kdepth, const int pad,
-    const int temporal_pad, const int stride, const int temporal_stride, double* data_im);
 
 void THNN_CudaVolumetricFullConvolution_updateOutput(
-  THCState *state,
-  THCudaTensor *input,
-  THCudaTensor *output,
-  THCudaTensor *weight,
-  THCudaTensor *bias,
-  THCudaTensor *finput,
-  THCudaTensor *fgradInput,
-  int dT, int dW, int dH,
-  int pT, int pW, int pH)
+    THCState *state,
+    THCudaTensor *input,
+    THCudaTensor *output,
+    THCudaTensor *weight,
+    THCudaTensor *bias,
+    THCudaTensor *finput,
+    THCudaTensor *fgradInput,
+    int dT, int dW, int dH,
+    int padT, int padW, int padH,
+    int adjT, int adjW, int adjH)
 {
-  // number of input/output planes and kernel size is indirectly defined by the weight tensor
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
-
-  int nOutputPlane = (int)weight->size[0];
-  int nInputPlane  = (int)weight->size[1];
-  int kT           = (int)weight->size[2];
-  int kW           = (int)weight->size[3];
-  int kH           = (int)weight->size[4];
 
   THCudaTensor *columns = finput;
-  THCudaTensor *ones = fgradInput;
+  THCudaTensor *ones    = fgradInput;
 
-  int inputDepth   = input->size[2];
-  int inputHeight  = input->size[3];
-  int inputWidth   = input->size[4];
+  int nInputPlane = THCudaTensor_size(state, weight, 0);
+  int nOutputPlane = THCudaTensor_size(state, weight, 1);
+  const int kT           = (int)weight->size[2];
+  const int kH           = (int)weight->size[3];
+  const int kW           = (int)weight->size[4];
 
-  int outputDepth  = (inputDepth - 1)  * dT - 2 * pT + kT;
-  int outputHeight = (inputHeight - 1) * dH - 2 * pH + kH;
-  int outputWidth  = (inputWidth - 1)  * dW - 2 * pW + kW;
+  THAssert(THCudaTensor_checkGPU(state, 6, input, output, weight,
+                                 bias, columns, ones));
+  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
 
-  THAssert(THCudaTensor_checkGPU(state, 6, input, output, weight, bias, columns, ones));
-  THArgCheck(input->nDimension == 5, 2, "5D (batch mode) tensor is expected");
-  THArgCheck(kH == kW && pH == pW, 2, "kH == kW && pH == pW is expected");
+  int batch = 1;
+  if (input->nDimension == 4) {
+    THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    // Force batch
+    batch = 0;
+    THCudaTensor_resize5d(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
+  } else {
+    THArgCheck(input->size[1] == nInputPlane, 2, "input channels and nInputPlane dont match");
+  }
 
-  // Batch size
+  long inputWidth   = input->size[4];
+  long inputHeight  = input->size[3];
+  long inputDepth  = input->size[2];
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
+  long outputDepth = (inputDepth - 1) * dT - 2*padT + kT + adjT;
+
+  // Batch size + input planes
   long batchSize = input->size[0];
 
-  // Figure out the dimensions for individual gemms.
-  int M_ = nInputPlane;
-  int K_ = nOutputPlane * kT * kH * kW;
-  int N_ = inputDepth * inputHeight * inputWidth;
-  int N0_ = outputDepth * outputHeight * outputWidth;
-
   // Resize output
-  THCudaTensor_resize5d(state, output, batchSize, nOutputPlane, outputDepth,
-                        outputHeight, outputWidth);
+  THCudaTensor_resize5d(state, output, batchSize, nOutputPlane, outputDepth, outputHeight, outputWidth);
 
   // Resize temporary columns
-  THCudaTensor_resize5d(state, columns, 1, nOutputPlane * kT * kH * kW, inputDepth, inputHeight, inputWidth);
+  THCudaTensor_resize2d(state, columns, nOutputPlane*kW*kH*kT, inputDepth*inputHeight*inputWidth);
 
   // Define a buffer of ones, for bias accumulation
   // Note: this buffer can be shared with other modules, it only ever gets increased,
   // and always contains ones.
-  if (ones->nDimension != 3 ||
-    ones->size[0] * ones->size[1] * ones->size[2] < outputDepth * outputHeight * outputWidth)
-  {
+  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCudaTensor_resize3d(state, ones, outputDepth, outputHeight, outputWidth);
     THCudaTensor_fill(state, ones, 1);
@@ -208,227 +67,286 @@ void THNN_CudaVolumetricFullConvolution_updateOutput(
   THCudaTensor *input_n = THCudaTensor_new(state);
   THCudaTensor *output_n = THCudaTensor_new(state);
 
-  for (int n = 0; n < batchSize; ++n)
-  {
-    THCudaTensor_select(state, input_n, input, 0, n);
-    THCudaTensor_select(state, output_n, output, 0, n);
+  // For each elt in batch, do:
+  for (int elt = 0; elt < batchSize; elt ++) {
+    // Matrix mulitply per output:
+    THCudaTensor_select(state, input_n, input, 0, elt);
+    THCudaTensor_select(state, output_n, output, 0, elt);
 
-    // do gemm
-    THCudaBlas_gemm(state, 'n', 't', N_, K_, M_,
-    1, THCudaTensor_data(state, input_n), N_,
-    THCudaTensor_data(state, weight), K_,
-    0, THCudaTensor_data(state, columns), N_);
+    // M,N,K are dims of matrix A and B
+    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+    long m = weight->size[1] * weight->size[2] * weight->size[3] * weight->size[4];
+    long n = columns->size[1];
+    long k = weight->size[0];
 
-    // col2vol from columns -> output
-    col2vol<float>(THCudaTensor_data(state, columns), nOutputPlane, outputDepth, outputHeight, outputWidth,
-    kH, kT, pH, pT, dH, dT,
-    THCudaTensor_data(state, output_n));
+    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
+    THCudaBlas_gemm(
+        state,
+        'n', 't',
+        n, m, k,
+        1,
+        THCudaTensor_data(state, input_n), n,
+        THCudaTensor_data(state, weight), m,
+        0,
+        THCudaTensor_data(state, columns), n
+    );
 
-    // third, add bias
-    THCudaBlas_gemm(state, 'n', 'n', N0_, nOutputPlane,
-    1, 1,
-    THCudaTensor_data(state, ones), N0_,
-    THCudaTensor_data(state, bias), 1,
-    1, THCudaTensor_data(state, output_n), N0_);
+    // Unpack columns back into input:
+    col2vol(
+      THCState_getCurrentStream(state),
+      THCudaTensor_data(state, columns),
+      nOutputPlane, outputDepth, outputHeight, outputWidth, kT, kH, kW, padT, padH, padW, dT, dH, dW,
+      THCudaTensor_data(state, output_n)
+    );
+
+    // Do Bias after:
+    // M,N,K are dims of matrix A and B
+    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+    long m_ = nOutputPlane;
+    long n_ = outputDepth * outputHeight * outputWidth;
+    long k_ = 1;
+
+    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
+    THCudaBlas_gemm(
+        state,
+        't', 'n',
+        n_, m_, k_,
+        1,
+        THCudaTensor_data(state, ones), k_,
+        THCudaTensor_data(state, bias), k_,
+        1,
+        THCudaTensor_data(state, output_n), n_
+    );
 
   }
+
+  // Free
   THCudaTensor_free(state, input_n);
   THCudaTensor_free(state, output_n);
+
+  // Resize output
+  if (batch == 0) {
+    THCudaTensor_resize4d(state, output, nOutputPlane, outputDepth, outputHeight, outputWidth);
+    THCudaTensor_resize4d(state, input, nInputPlane, inputDepth, inputHeight, inputWidth);
+  }
 }
 
 void THNN_CudaVolumetricFullConvolution_updateGradInput(
-  THCState *state,
-  THCudaTensor *input,
-  THCudaTensor *gradOutput,
-  THCudaTensor *gradInput,
-  THCudaTensor *weight,
-  THCudaTensor *finput,
-  THCudaTensor *fgradInput,
-  int dT, int dW, int dH,
-  int pT, int pW, int pH)
+    THCState *state,
+    THCudaTensor *input,
+    THCudaTensor *gradOutput,
+    THCudaTensor *gradInput,
+    THCudaTensor *weight,
+    THCudaTensor *finput,
+    THCudaTensor *fgradInput,
+    int dT, int dW, int dH,
+    int padT, int padW, int padH,
+    int adjT, int adjW, int adjH)
 {
-  // number of input/output planes and kernel size is indirectly defined by the weight tensor
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
-
-  int nOutputPlane = (int)weight->size[0];
-  int nInputPlane  = (int)weight->size[1];
-  int kT           = (int)weight->size[2];
-  int kW           = (int)weight->size[3];
-  int kH           = (int)weight->size[4];
-
   THCudaTensor *gradColumns = finput;
+
+  int nInputPlane = THCudaTensor_size(state, weight, 0);
+  int nOutputPlane = THCudaTensor_size(state, weight, 1);
+  const int kT           = (int)weight->size[2];
+  const int kH           = (int)weight->size[3];
+  const int kW           = (int)weight->size[4];
 
   THAssert(THCudaTensor_checkGPU(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput));
-  THArgCheck(input->nDimension == 5, 2, "5D (batch mode) tensor is expected");
-  THArgCheck(kH == kW && pH == pW, 2, "kH == kW && pH == pW is expected");
+  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
 
-  int inputDepth   = input->size[2];
-  int inputHeight  = input->size[3];
-  int inputWidth   = input->size[4];
+  int batch = 1;
+  if (input->nDimension == 4) {
+    // Force batch
+    batch = 0;
+    THCudaTensor_resize5d(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
+    THCudaTensor_resize5d(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
+  }
 
-  int outputDepth  = (inputDepth - 1) * dT - 2 * pT + kT;
-  int outputHeight = (inputHeight - 1) * dH - 2 * pH + kH;
-  int outputWidth  = (inputWidth - 1) * dW - 2 * pW + kW;
+  long inputWidth   = input->size[4];
+  long inputHeight  = input->size[3];
+  long inputDepth   = input->size[2];
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
+  long outputDepth = (inputDepth - 1) * dT - 2*padT + kT + adjT;
 
-  // Batch size
-  int batchSize = input->size[0];
-
-  // Figure out the dimensions for individual gemms.
-  int M_ = nInputPlane;
-  int K_ = nOutputPlane * kT * kH * kW;
-  int N_ = inputDepth * inputHeight * inputWidth;
+  // Batch size + input planes
+  long batchSize = input->size[0];
 
   // Resize output
   THCudaTensor_resize5d(state, gradInput, batchSize, nInputPlane, inputDepth, inputHeight, inputWidth);
 
   // Resize temporary columns
-  THCudaTensor_resize5d(state, gradColumns, 1, nOutputPlane * kT * kH * kW, inputDepth, inputHeight, inputWidth);
+  THCudaTensor_resize2d(state, gradColumns, nOutputPlane*kW*kH*kT, inputDepth*inputHeight*inputWidth);
 
   // Helpers
   THCudaTensor *gradInput_n = THCudaTensor_new(state);
   THCudaTensor *gradOutput_n = THCudaTensor_new(state);
 
-  // For each n in batch, do:
-  for (int n = 0; n < batchSize; n++)
-  {
-    THCudaTensor_select(state, gradInput_n, gradInput, 0, n);
-    THCudaTensor_select(state, gradOutput_n, gradOutput, 0, n);
+  // For each elt in batch, do:
+  for (int elt = 0; elt < batchSize; elt ++) {
+    // Matrix mulitply per sample:
+    THCudaTensor_select(state, gradInput_n, gradInput, 0, elt);
+    THCudaTensor_select(state, gradOutput_n, gradOutput, 0, elt);
 
-    // vol2col from gradOutput to gradColumns
-    vol2col<float>(
+    // Extract columns:
+    vol2col(
+      THCState_getCurrentStream(state),
       THCudaTensor_data(state, gradOutput_n),
-      nOutputPlane,
-      outputDepth, outputHeight, outputWidth,
-      kH, kT, pH,
-      pT, dH, dT,
+      nOutputPlane, outputDepth, outputHeight, outputWidth, kT, kH, kW, padT, padH, padW, dT, dH, dW,
       THCudaTensor_data(state, gradColumns)
     );
 
-    // gemm to compute gradInput
+
+    // M,N,K are dims of matrix A and B
+    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+    long m = weight->size[0];
+    long n = gradColumns->size[1];
+    long k = weight->size[1] * weight->size[2] * weight->size[3] * weight->size[4];
+
+    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THCudaBlas_gemm(
-      state, 'n', 'n', N_, M_, K_,
-      1, THCudaTensor_data(state, gradColumns), N_,
-      THCudaTensor_data(state, weight), K_,
-      0, THCudaTensor_data(state, gradInput_n), N_
+        state,
+        'n', 'n',
+        n, m, k,
+        1,
+        THCudaTensor_data(state, gradColumns), n,
+        THCudaTensor_data(state, weight), k,
+        0,
+        THCudaTensor_data(state, gradInput_n), n
     );
   }
+
 
   // Free
   THCudaTensor_free(state, gradInput_n);
   THCudaTensor_free(state, gradOutput_n);
+
+  // Resize output
+  if (batch == 0) {
+    THCudaTensor_resize4d(state, gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
+    THCudaTensor_resize4d(state, input, nInputPlane, inputDepth, inputHeight, inputWidth);
+    THCudaTensor_resize4d(state, gradInput, nInputPlane, inputDepth, inputHeight, inputWidth);
+  }
 }
 
+
 void THNN_CudaVolumetricFullConvolution_accGradParameters(
-  THCState *state,
-  THCudaTensor *input,
-  THCudaTensor *gradOutput,
-  THCudaTensor *gradWeight,
-  THCudaTensor *gradBias,
-  THCudaTensor *finput,
-  THCudaTensor *fgradInput,
-  int dT, int dW, int dH,
-  int pT, int pW, int pH,
-  float scale)
+    THCState *state,
+    THCudaTensor *input,
+    THCudaTensor *gradOutput,
+    THCudaTensor *gradWeight,
+    THCudaTensor *gradBias,
+    THCudaTensor *finput,
+    THCudaTensor *fgradInput,
+    int dT, int dW, int dH,
+    int padT, int padW, int padH,
+    int adjT, int adjW, int adjH,
+    float scale)
 {
-  // number of input/output planes and kernel size is indirectly defined by the gradWeight tensor
-  THArgCheck(gradWeight->nDimension == 5, 4,
-    "5D gradWeight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
-
-  int nOutputPlane = (int)gradWeight->size[0];
-  int nInputPlane  = (int)gradWeight->size[1];
-  int kT           = (int)gradWeight->size[2];
-  int kW           = (int)gradWeight->size[3];
-  int kH           = (int)gradWeight->size[4];
-
-  THCudaTensor *gradColumns = finput;
+  THCudaTensor *columns = finput;
   THCudaTensor *ones = fgradInput;
 
+  int nInputPlane = THCudaTensor_size(state, gradWeight, 0);
+  int nOutputPlane = THCudaTensor_size(state, gradWeight, 1);
+  const int kT           = (int)gradWeight->size[2];
+  const int kH           = (int)gradWeight->size[3];
+  const int kW           = (int)gradWeight->size[4];
+
   THAssert(THCudaTensor_checkGPU(state, 6, input, gradOutput, gradWeight,
-                                 gradBias, gradColumns, ones));
-  THArgCheck(input->nDimension == 5, 2, "5D (batch mode) tensor is expected");
-  THArgCheck(kH == kW && pH == pW, 2, "kH == kW && pH == pW is expected");
+                                 gradBias, columns, ones));
+  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
 
-  THCudaTensor_resize1d(state, gradBias, nOutputPlane);
-  THCudaTensor_resize5d(state, gradWeight, nOutputPlane, nInputPlane, kT, kH, kW);
+  int batch = 1;
+  if (input->nDimension == 4) {
+    // Force batch
+    batch = 0;
+    THCudaTensor_resize5d(state, input, 1, input->size[0], input->size[1], input->size[2], input->size[3]);
+    THCudaTensor_resize5d(state, gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2], gradOutput->size[3]);
+  }
 
-  int inputDepth   = input->size[2];
-  int inputHeight  = input->size[3];
-  int inputWidth   = input->size[4];
+  long inputWidth   = input->size[4];
+  long inputHeight  = input->size[3];
+  long inputDepth   = input->size[2];
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
+  long outputDepth  = (inputDepth - 1) * dT - 2*padT + kT + adjT;
 
-  int outputDepth  = (inputDepth - 1) * dT - 2 * pT + kT;
-  int outputHeight = (inputHeight - 1) * dH - 2 * pH + kH;
-  int outputWidth  = (inputWidth - 1) * dW - 2 * pW + kW;
-
-  // Batch size
+  // Batch size + input planes
   long batchSize = input->size[0];
 
-  // Figure out the dimensions for individual gemms.
-  int M_ = nInputPlane;
-  int K_ = nOutputPlane * kT * kH * kW;
-  int N_ = inputDepth * inputHeight * inputWidth;
-  int N0_ = outputDepth * outputHeight * outputWidth;
-
-  // Resize temporary columns
-  THCudaTensor_resize5d(state, gradColumns, 1, nOutputPlane * kT * kH * kW, inputDepth, inputHeight, inputWidth);
-
-  if (ones->nDimension != 3 ||
-    ones->size[0] * ones->size[1] * ones->size[2] < outputDepth * outputHeight * outputWidth)
-  {
+  // Define a buffer of ones, for bias accumulation
+  if (ones->nDimension != 3 || ones->size[0]*ones->size[1]*ones->size[2] < outputDepth*outputHeight*outputWidth) {
     // Resize plane and fill with ones...
     THCudaTensor_resize3d(state, ones, outputDepth, outputHeight, outputWidth);
     THCudaTensor_fill(state, ones, 1);
   }
 
+  // Resize temporary columns
+  THCudaTensor_resize2d(state, columns, nOutputPlane*kW*kH*kT, inputDepth*inputHeight*inputWidth);
+
   // Helpers
   THCudaTensor *input_n = THCudaTensor_new(state);
   THCudaTensor *gradOutput_n = THCudaTensor_new(state);
 
-  // reset gradBias = 0
-  CUDA_CHECK(cudaMemset(THCudaTensor_data(state, gradBias), 0,
-      sizeof(float) * nOutputPlane));
+  // For each elt in batch, do:
+  for (int elt = 0; elt < batchSize; elt ++) {
+    // Matrix mulitply per output:
+    THCudaTensor_select(state, input_n, input, 0, elt);
+    THCudaTensor_select(state, gradOutput_n, gradOutput, 0, elt);
 
-  // reset gradWeight = 0
-  CUDA_CHECK(cudaMemset(THCudaTensor_data(state, gradWeight), 0,
-              sizeof(float) * M_ * K_));
-
-  // For each n in batch, do:
-  for (int n = 0; n < batchSize; n++)
-  {
-    THCudaTensor_select(state, input_n, input, 0, n);
-    THCudaTensor_select(state, gradOutput_n, gradOutput, 0, n);
-
-    // accumulate gradBias
-    THCudaBlas_gemv(
-      state, 't', N0_, nOutputPlane, 1,
-      THCudaTensor_data(state, gradOutput_n), N0_,
-      THCudaTensor_data(state, ones), 1,
-      1,
-      THCudaTensor_data(state, gradBias), 1
-    );
-
-    vol2col<float>(
+    // Extract columns:
+    vol2col(
+      THCState_getCurrentStream(state),
       THCudaTensor_data(state, gradOutput_n),
-      nOutputPlane,
-      outputDepth, outputHeight, outputWidth,
-      kH, kT, pH,
-      pT, dH, dT,
-      THCudaTensor_data(state, gradColumns)
+      nOutputPlane, outputDepth, outputHeight, outputWidth, kT, kH, kW, padT, padH, padW, dT, dH, dW,
+      THCudaTensor_data(state, columns)
     );
 
-    // accummulate gradWeight
+    // M,N,K are dims of matrix A and B
+    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+    long n = columns->size[0];   // nOutputPlane * kt * kh * kw
+    long m = input_n->size[0];   // nInputPlane
+    long k = columns->size[1];   // inputHeight * inputWidth
+
+    // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     THCudaBlas_gemm(
-      state, 't', 'n', K_, M_, N_,
-      1, THCudaTensor_data(state, gradColumns), N_,
-      THCudaTensor_data(state, input_n), N_,
-      1, THCudaTensor_data(state, gradWeight), K_
+        state,
+        't', 'n',
+        n, m, k,
+        scale,
+        THCudaTensor_data(state, columns), k,
+        THCudaTensor_data(state, input_n), k,
+        1,
+        THCudaTensor_data(state, gradWeight), n
+    );
+
+    // Do Bias:
+    // M,N,K are dims of matrix A and B
+    // (see http://docs.nvidia.com/cuda/cublas/#cublas-lt-t-gt-gemm)
+    long m_ = nOutputPlane;
+    long k_ = outputDepth * outputHeight * outputWidth;
+
+    // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
+    THCudaBlas_gemv(
+        state,
+        't',
+        k_, m_,
+        scale,
+        THCudaTensor_data(state, gradOutput_n), k_,
+        THCudaTensor_data(state, ones), 1,
+        1,
+        THCudaTensor_data(state, gradBias), 1
     );
   }
 
   // Free
   THCudaTensor_free(state, input_n);
   THCudaTensor_free(state, gradOutput_n);
+
+  // Resize
+  if (batch == 0) {
+    THCudaTensor_resize4d(state, gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
+    THCudaTensor_resize4d(state, input, nInputPlane, inputDepth, inputHeight, inputWidth);
+  }
 }

--- a/lib/THCUNN/vol2col.h
+++ b/lib/THCUNN/vol2col.h
@@ -1,0 +1,120 @@
+#ifndef THCUNN_VOL2COL_H
+#define THCUNN_VOL2COL_H
+
+#include "common.h"
+
+// Kernel for fast unfold+copy on volumes
+template <typename Dtype>
+__global__ void vol2col_kernel(const int n, const Dtype* data_vol,
+    const int depth, const int height, const int width,
+    const int ksize_t, const int ksize_h, const int ksize_w,
+    const int pad_t, const int pad_h, const int pad_w,
+    const int stride_t, const int stride_h, const int stride_w,
+    const int depth_col, const int height_col, const int width_col,
+    Dtype* data_col) {
+  CUDA_KERNEL_LOOP(index, n) {
+    int w_out = index % width_col;
+    index /= width_col;
+    int h_out = index % height_col;
+    index /= height_col;
+    int t_out = index % depth_col;
+    int channel_in = index / depth_col;
+    int channel_out = channel_in * ksize_t * ksize_h * ksize_w;
+    int t_in = t_out * stride_t - pad_t;
+    int h_in = h_out * stride_h - pad_h;
+    int w_in = w_out * stride_w - pad_w;
+    data_col += ((channel_out * depth_col + t_out) * height_col + h_out) * width_col + w_out;
+    data_vol += ((channel_in * depth + t_in) * height + h_in) * width + w_in;
+    for (int i = 0; i < ksize_t; ++i) {
+      for (int j = 0; j < ksize_h; ++j) {
+        for (int k = 0; k < ksize_w; ++k) {
+          int t = t_in + i;
+          int h = h_in + j;
+          int w = w_in + k;
+          *data_col = (t >= 0 && h >= 0 && w >= 0 && t < depth && h < height && w < width) ?
+            data_vol[(i * height + j) * width + k] : 0;
+          data_col += depth_col * height_col * width_col;
+        }
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void vol2col(cudaStream_t stream, const Dtype* data_vol, const int channels,
+    const int depth, const int height, const int width,
+    const int ksize_t, const int ksize_h, const int ksize_w,
+    const int pad_t, const int pad_h, const int pad_w,
+    const int stride_t, const int stride_h, const int stride_w, Dtype* data_col) {
+  // We are going to launch channels * depth_col * height_col * width_col kernels, each
+  // kernel responsible for copying a single-channel grid.
+  int depth_col = (depth + 2 * pad_t - ksize_t) / stride_t + 1;
+  int height_col = (height + 2 * pad_h - ksize_h) / stride_h + 1;
+  int width_col = (width + 2 * pad_w - ksize_w) / stride_w + 1;
+  int num_kernels = channels * depth_col * height_col * width_col;
+  // Launch
+  vol2col_kernel <<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, stream>>> (
+      num_kernels, data_vol, depth, height, width, ksize_t, ksize_h, ksize_w,
+      pad_t, pad_h, pad_w, stride_t, stride_h, stride_w,
+      depth_col, height_col, width_col, data_col
+  );
+}
+
+template <typename Dtype>
+__global__ void vol2im_kernel(const int n, const Dtype* data_col,
+    const int depth, const int height, const int width, const int channels,
+    const int patch_t, const int patch_h, const int patch_w,
+    const int pad_t, const int pad_h, const int pad_w,
+    const int stride_t, const int stride_h, const int stride_w,
+    const int depth_col, const int height_col, const int width_col,
+    Dtype* data_vol) {
+  CUDA_KERNEL_LOOP(index, n) {
+    Dtype val = 0;
+    int w = index % width + pad_w;
+    int h = (index / width) % height + pad_h;
+    int t = (index / width / height) % depth + pad_t;
+    int c = index / (width * height * depth);
+    // compute the start and end of the output
+    int w_col_start = (w < patch_w) ? 0 : (w - patch_w) / stride_w + 1;
+    int w_col_end = min(w / stride_w + 1, width_col);
+    int h_col_start = (h < patch_h) ? 0 : (h - patch_h) / stride_h + 1;
+    int h_col_end = min(h / stride_h + 1, height_col);
+    int t_col_start = (t < patch_t) ? 0 : (t - patch_t) / stride_t + 1;
+    int t_col_end = min(t / stride_t + 1, depth_col);
+
+    int offset = (((c * patch_t + t) * patch_h + h) * patch_w + w) * depth_col * height_col * width_col;
+    int coeff_t_col = (1 - stride_t * patch_h * patch_w * depth_col) * height_col * width_col;
+    int coeff_h_col = (1 - stride_h * patch_w * depth_col * height_col) * width_col;
+    int coeff_w_col = (1 - stride_w * depth_col * height_col * width_col) ;
+
+    for (int t_col = t_col_start; t_col < t_col_end; ++t_col) {
+      for (int h_col = h_col_start; h_col < h_col_end; ++h_col) {
+        for (int w_col = w_col_start; w_col < w_col_end; ++w_col) {
+          val += data_col[offset + t_col * coeff_t_col + h_col * coeff_h_col + w_col * coeff_w_col];
+        }
+      }
+    }
+    data_vol[index] = val;
+  }
+}
+
+template <typename Dtype>
+void col2vol(cudaStream_t stream, const Dtype* data_col, const int channels,
+    const int depth, const int height, const int width,
+    const int patch_t, const int patch_h, const int patch_w,
+    const int pad_t, const int pad_h, const int pad_w,
+    const int stride_t, const int stride_h, const int stride_w, Dtype* data_vol) {
+  int depth_col = (depth + 2 * pad_t - patch_t) / stride_t + 1;
+  int height_col = (height + 2 * pad_h - patch_h) / stride_h + 1;
+  int width_col = (width + 2 * pad_w - patch_w) / stride_w + 1;
+  int num_kernels = channels * depth * height * width;
+  // To avoid involving atomic operations, we will launch one kernel per
+  // bottom dimension, and then in the kernel add up the top dimensions.
+  vol2im_kernel <<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, stream>>> (
+      num_kernels, data_col, depth, height, width, channels,
+      patch_t, patch_h, patch_w, pad_t, pad_h, pad_w, stride_t, stride_h, stride_w,
+      depth_col, height_col, width_col, data_vol
+  );
+}
+
+#endif

--- a/test.lua
+++ b/test.lua
@@ -4168,6 +4168,7 @@ function cunntest.VolumetricFullConvolution()
         end
     end
 
+    module:zeroGradParameters()
     local gradOut = torch.Tensor(1, 1, 6, 6, 6):fill(0.1);
     local gradIn = module:backward(input:cuda(), gradOut:cuda())
     for t = 1,2 do
@@ -4185,7 +4186,7 @@ function cunntest.VolumetricFullConvolution()
         for t = 1,3 do
             for h = 1,3 do
                 for w = 1,3 do
-                    mytester:assertlt(module.gradWeight[1][c][t][h][w] - 0.1, precision_backward,
+                    mytester:assertlt(module.gradWeight[c][1][t][h][w] - 0.1, precision_backward,
                                       'error on backward weight gradients ')
                 end
             end


### PR DESCRIPTION
The module didn't pass gradients check and had limitations (batch mode only, constraints on kernel size and padding). This new implementation removes these limitations, and is now implemented like SpatialFullConvolution.