### PR TITLE
THNN -> THCUNN in assertSameGPU

### DIFF
--- a/lib/THCUNN/Abs.cu
+++ b/lib/THCUNN/Abs.cu
@@ -11,7 +11,7 @@ struct absupdateOutput_functor
 
 void THNN_CudaAbs_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, absupdateOutput_functor());
 }
@@ -26,7 +26,7 @@ struct absupdateGradInput_functor
 
 void THNN_CudaAbs_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput)
 {
-  THNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, input);
   THCudaTensor_pointwiseApply3(state, gradInput, input, gradOutput, absupdateGradInput_functor());
 }

--- a/lib/THCUNN/AbsCriterion.cu
+++ b/lib/THCUNN/AbsCriterion.cu
@@ -18,7 +18,7 @@ struct abs_functor
 
 void THNN_CudaAbsCriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
 
   long size = THCudaTensor_nElement(state, input);
 
@@ -54,7 +54,7 @@ struct abs_updateGradInput_functor
 
 void THNN_CudaAbsCriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
 
   long size = THCudaTensor_nElement(state, input);
   float norm = (sizeAverage ? 1./size : 1.);

--- a/lib/THCUNN/ClassNLLCriterion.cu
+++ b/lib/THCUNN/ClassNLLCriterion.cu
@@ -116,11 +116,11 @@ void THNN_CudaClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *inpu
   int n_classes = THCudaTensor_size(state, input, n_dims - 1);
 
   if (weights) {
-    THNN_assertSameGPU(
+    THCUNN_assertSameGPU(
       state, 5, input, target, weights, output, total_weight
     );
   } else {
-    THNN_assertSameGPU(
+    THCUNN_assertSameGPU(
       state, 4, input, target, output, total_weight
     );
   }
@@ -188,12 +188,12 @@ void THNN_CudaClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *i
   THArgCheck(THCudaTensor_isContiguous(state, gradInput), 4, "gradInput must be contiguous");
 
   if (weights) {
-    THNN_assertSameGPU(
+    THCUNN_assertSameGPU(
       state, 5, weights, input, target, gradInput, total_weight
     );
   }
   else {
-    THNN_assertSameGPU(
+    THCUNN_assertSameGPU(
       state, 4, input, target, gradInput, total_weight
     );
   }

--- a/lib/THCUNN/DistKLDivCriterion.cu
+++ b/lib/THCUNN/DistKLDivCriterion.cu
@@ -17,7 +17,7 @@ struct kl_functor
 
 void THNN_CudaDistKLDivCriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
 
   THArgCheck(THCudaTensor_nElement(state, input) == THCudaTensor_nElement(state, target), 2,
              "input and target need to have the same number of elements");
@@ -58,7 +58,7 @@ struct kl_updateGradInput_functor
 
 void THNN_CudaDistKLDivCriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
 
   THArgCheck(THCudaTensor_nElement(state, input) == THCudaTensor_nElement(state, target), 2,
              "input and target need to have the same number of elements");

--- a/lib/THCUNN/ELU.cu
+++ b/lib/THCUNN/ELU.cu
@@ -17,7 +17,7 @@ struct ELUupdateOutput_functor
 
 void THNN_CudaELU_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, float alpha)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, ELUupdateOutput_functor(alpha));
 }
@@ -39,7 +39,7 @@ struct ELUupdateGradInput_functor
 void THNN_CudaELU_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput,
   THCudaTensor *gradInput, THCudaTensor *output, float alpha)
 {
-  THNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, output);
   THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, ELUupdateGradInput_functor(alpha));
 }

--- a/lib/THCUNN/HardTanh.cu
+++ b/lib/THCUNN/HardTanh.cu
@@ -24,7 +24,7 @@ struct hardtanhupdateOutput_functor
 
 void THNN_CudaHardTanh_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, float min_val, float max_val)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input,
                                hardtanhupdateOutput_functor(min_val, max_val));
@@ -51,7 +51,7 @@ struct hardtanhupdateGradInput_functor
 
 void THNN_CudaHardTanh_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, float min_val, float max_val)
 {
-  THNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
 
   THCudaTensor_resizeAs(state, gradInput, input);
   THCudaTensor_pointwiseApply3(state, gradInput, input, gradOutput,

--- a/lib/THCUNN/L1Cost.cu
+++ b/lib/THCUNN/L1Cost.cu
@@ -15,7 +15,7 @@ struct l1cost_functor
 
 void THNN_CudaL1Cost_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 1, input);
+  THCUNN_assertSameGPU(state, 1, input);
   float sum;
   long size = THCudaTensor_nElement(state, input);
   input = THCudaTensor_newContiguous(state, input);
@@ -42,7 +42,7 @@ struct l1cost_updateGradInput_functor
 
 void THNN_CudaL1Cost_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput)
 {
-  THNN_assertSameGPU(state, 2, input, gradInput);
+  THCUNN_assertSameGPU(state, 2, input, gradInput);
   long size = THCudaTensor_nElement(state, input);
 
   input = THCudaTensor_newContiguous(state, input);

--- a/lib/THCUNN/LeakyReLU.cu
+++ b/lib/THCUNN/LeakyReLU.cu
@@ -34,7 +34,7 @@ struct LeakyReLUUpdateOutputIP
 void THNN_CudaLeakyReLU_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output,
   double negval, bool inplace)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
 
   if (inplace)
   {
@@ -86,7 +86,7 @@ struct LeakyReLUUpdateGradInputIP
 void THNN_CudaLeakyReLU_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput,
   THCudaTensor *gradInput, double negval, bool inplace)
 {
-  THNN_assertSameGPU(state, 3, input, gradInput, gradOutput);
+  THCUNN_assertSameGPU(state, 3, input, gradInput, gradOutput);
 
   if (inplace)
   {

--- a/lib/THCUNN/LogSigmoid.cu
+++ b/lib/THCUNN/LogSigmoid.cu
@@ -12,7 +12,7 @@ struct logSigmoid_updateOutput_functor
 
 void THNN_CudaLogSigmoid_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, THCudaTensor *buffer)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, logSigmoid_updateOutput_functor());
 }
@@ -29,7 +29,7 @@ struct logSigmoid_updateGradInput_functor
 void THNN_CudaLogSigmoid_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput,
   THCudaTensor *gradInput , THCudaTensor *buffer)
 {
-  THNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, input);
   THCudaTensor_pointwiseApply3(state, gradInput, input, gradOutput, logSigmoid_updateGradInput_functor());
 }

--- a/lib/THCUNN/LogSoftMax.cu
+++ b/lib/THCUNN/LogSoftMax.cu
@@ -249,7 +249,7 @@ cunn_LogSoftMax_updateGradInput_kernel(float *gradInput,
 
 void THNN_CudaLogSoftMax_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
 
   input = THCudaTensor_newContiguous(state, input);
   THCudaTensor_resizeAs(state, output, input);
@@ -293,7 +293,7 @@ void THNN_CudaLogSoftMax_updateOutput(THCState *state, THCudaTensor *input, THCu
 void THNN_CudaLogSoftMax_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput,
   THCudaTensor *gradInput, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
 
   output = THCudaTensor_newContiguous(state, output);
   gradOutput = THCudaTensor_newContiguous(state, gradOutput);

--- a/lib/THCUNN/LookupTable.cu
+++ b/lib/THCUNN/LookupTable.cu
@@ -169,7 +169,7 @@ void THNN_CudaLookupTable_accGradParameters(
   int paddingValue,
   float scale)
 {
-  THNN_assertSameGPU(state, 5, input, gradOutput, gradWeight, sorted, indices);
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, gradWeight, sorted, indices);
   if (!(THCudaTensor_isContiguous(state, input) &&
         THCudaTensor_isContiguous(state, gradOutput) &&
         THCudaTensor_isContiguous(state, gradWeight)))

--- a/lib/THCUNN/MSECriterion.cu
+++ b/lib/THCUNN/MSECriterion.cu
@@ -23,7 +23,7 @@ struct mse_functor
 
 void THNN_CudaMSECriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
   THArgCheck(THCudaTensor_nElement(state, input) == THCudaTensor_nElement(state, target), 2,
     "input and target need to have the same number of elements"
   );
@@ -67,7 +67,7 @@ struct mse_updateGradInput_functor
 
 void THNN_CudaMSECriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
   THArgCheck(THCudaTensor_nElement(state, input) == THCudaTensor_nElement(state, target), 2,
     "input and target need to have the same number of elements"
   );

--- a/lib/THCUNN/MarginCriterion.cu
+++ b/lib/THCUNN/MarginCriterion.cu
@@ -24,7 +24,7 @@ struct margin_functor
 
 void THNN_CudaMarginCriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, float margin)
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
 
   long size = THCudaTensor_nElement(state, input);
 
@@ -61,7 +61,7 @@ struct margin_updateGradInput_functor
 
 void THNN_CudaMarginCriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, float margin)
 {
-  THNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
 
   long size = THCudaTensor_nElement(state, input);
   float norm = sizeAverage ? 1.f/size : 1;

--- a/lib/THCUNN/MultiMarginCriterion.cu
+++ b/lib/THCUNN/MultiMarginCriterion.cu
@@ -96,7 +96,7 @@ void THNN_CudaMultiMarginCriterion_updateOutput(THCState *state, THCudaTensor *i
                                                 THCudaTensor *target, THCudaTensor *output,
                                                 bool sizeAverage, int p, THCudaTensor *weights)
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
   input = THCudaTensor_newContiguous(state, input);
   if(weights)
     weights = THCudaTensor_newContiguous(state, weights);
@@ -176,7 +176,7 @@ void THNN_CudaMultiMarginCriterion_updateGradInput(THCState *state, THCudaTensor
                                                    THCudaTensor *target, THCudaTensor *gradInput,
                                                    bool sizeAverage, int p, THCudaTensor *weights)
 {
-  THNN_assertSameGPU(state, 3, input, gradInput, target);
+  THCUNN_assertSameGPU(state, 3, input, gradInput, target);
   input = THCudaTensor_newContiguous(state, input);
   THCudaTensor_resizeAs(state, gradInput, input);
   if(weights)

--- a/lib/THCUNN/RReLU.cu
+++ b/lib/THCUNN/RReLU.cu
@@ -64,7 +64,7 @@ struct RReLUUpdateOutputEvalIP_functor
 void THNN_CudaRReLU_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output,
   THCudaTensor *noise, double lower, double upper, bool train, bool inplace, void *generator)
 {
-  THNN_assertSameGPU(state, 3, input, output, noise);
+  THCUNN_assertSameGPU(state, 3, input, output, noise);
   if (state->rngState->current_gen == NULL)
   {
     THError("Random number generators have not been initialized.");
@@ -144,7 +144,7 @@ struct RReLUupdateGradInputEvalIP_functor
 void THNN_CudaRReLU_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput,
   THCudaTensor *gradInput, THCudaTensor *noise, double lower, double upper, bool train, bool inplace)
 {
-  THNN_assertSameGPU(state, 4, input, gradOutput, gradInput, noise);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, gradInput, noise);
 
   gradOutput = THCudaTensor_newContiguous(state, gradOutput);
 

--- a/lib/THCUNN/Sigmoid.cu
+++ b/lib/THCUNN/Sigmoid.cu
@@ -11,7 +11,7 @@ struct sigmoidupdateOutput_functor
 
 void THNN_CudaSigmoid_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, sigmoidupdateOutput_functor());
 }
@@ -26,7 +26,7 @@ struct sigmoidupdateGradInput_functor
 
 void THNN_CudaSigmoid_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, output);
   THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, sigmoidupdateGradInput_functor());
 }

--- a/lib/THCUNN/SmoothL1Criterion.cu
+++ b/lib/THCUNN/SmoothL1Criterion.cu
@@ -23,7 +23,7 @@ struct smoothl1_functor
 
 void THNN_CudaSmoothL1Criterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
   THArgCheck(
     THCudaTensor_nElement(state, input) == THCudaTensor_nElement(state, target), 2,
     "input and target need to have the same number of elements"
@@ -75,7 +75,7 @@ struct smoothl1_updateGradInput_functor
 
 void THNN_CudaSmoothL1Criterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage)
 {
-  THNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
   THArgCheck(
     THCudaTensor_nElement(state, input) == THCudaTensor_nElement(state, target), 2,
     "input and target need to have the same number of elements"

--- a/lib/THCUNN/SoftMarginCriterion.cu
+++ b/lib/THCUNN/SoftMarginCriterion.cu
@@ -23,7 +23,7 @@ void THNN_CudaSoftMarginCriterion_updateOutput(THCState *state,
                                                int sizeAverage
                                               )
 {
-  THNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 2, input, target);
   float sum;
 
   long size = THCudaTensor_nElement(state, input);
@@ -66,7 +66,7 @@ void THNN_CudaSoftMarginCriterion_updateGradInput(THCState *state,
                                                   int sizeAverage
                                                  )
 {
-  THNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
 
   long size = THCudaTensor_nElement(state, input);
   float norm = (sizeAverage ? 1./size : 1.);

--- a/lib/THCUNN/SoftMax.cu
+++ b/lib/THCUNN/SoftMax.cu
@@ -105,7 +105,7 @@ __global__ void cunn_SoftMax_updateGradInput_kernel(
 
 void THNN_CudaSoftMax_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
 
   input = THCudaTensor_newContiguous(state, input);
   THCudaTensor_resizeAs(state, output, input);
@@ -157,7 +157,7 @@ void THNN_CudaSoftMax_updateOutput(THCState *state, THCudaTensor *input, THCudaT
 
 void THNN_CudaSoftMax_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
 
   output = THCudaTensor_newContiguous(state, output);
   gradOutput = THCudaTensor_newContiguous(state, gradOutput);

--- a/lib/THCUNN/SoftPlus.cu
+++ b/lib/THCUNN/SoftPlus.cu
@@ -20,7 +20,7 @@ struct softPlusupdateOutput_functor
 
 void THNN_CudaSoftPlus_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, float beta, float threshold)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, softPlusupdateOutput_functor(threshold, beta));
 }
@@ -46,7 +46,7 @@ struct softPlusupdateGradInput_functor
 void THNN_CudaSoftPlus_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput,
   THCudaTensor *output, float beta, float threshold)
 {
-  THNN_assertSameGPU(state, 4, input, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, output, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, output);
   THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, softPlusupdateGradInput_functor(threshold, beta));
 }

--- a/lib/THCUNN/SoftShrink.cu
+++ b/lib/THCUNN/SoftShrink.cu
@@ -20,7 +20,7 @@ struct SoftShrinkUpdateOutput
 
 void THNN_CudaSoftShrink_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, double lambda)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, SoftShrinkUpdateOutput(lambda));
   THCudaCheck(cudaGetLastError());
@@ -47,7 +47,7 @@ struct SoftShrinkUpdateGradInput
 
 void THNN_CudaSoftShrink_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, double lambda)
 {
-  THNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, input);
   THCudaTensor_pointwiseApply3(state, gradInput, input, gradOutput, SoftShrinkUpdateGradInput(lambda));
   THCudaCheck(cudaGetLastError());

--- a/lib/THCUNN/SpatialAdaptiveMaxPooling.cu
+++ b/lib/THCUNN/SpatialAdaptiveMaxPooling.cu
@@ -187,7 +187,7 @@ __global__ void atomicadaptivemaxgradinput(
 
 void THNN_CudaSpatialAdaptiveMaxPooling_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, THCudaTensor *indices, int nOutputCols, int nOutputRows)
 {
-  THNN_assertSameGPU(state, 3, input, output, indices);
+  THCUNN_assertSameGPU(state, 3, input, output, indices);
 
   float *indices_data;
   float *output_data;
@@ -270,7 +270,7 @@ void THNN_CudaSpatialAdaptiveMaxPooling_updateGradInput(THCState *state, THCudaT
 {
   bool atomic = true; // suboptimal, but without atomic it doesn't pass the tests
 
-  THNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
 
   float *indices_data;
   float *gradInput_data;

--- a/lib/THCUNN/SpatialAveragePooling.cu
+++ b/lib/THCUNN/SpatialAveragePooling.cu
@@ -39,7 +39,7 @@ __global__ void AvePoolForward(const int nthreads,
 
 void THNN_CudaSpatialAveragePooling_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, int kW, int kH, int dW, int dH, int padW, int padH, bool ceil_mode, bool count_include_pad)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch) tensor expected");
 
   long nInputCols, nInputRows, nInputPlane, batchSize;
@@ -160,7 +160,7 @@ __global__ void AvePoolBackward(const int nthreads, const Dtype* const top_diff,
 
 void THNN_CudaSpatialAveragePooling_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, int kW, int kH, int dW, int dH, int padW, int padH, bool ceil_mode, bool count_include_pad)
 {
-  THNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
 
   input = THCudaTensor_newContiguous(state, input);
   gradOutput = THCudaTensor_newContiguous(state, gradOutput);

--- a/lib/THCUNN/SpatialConvolutionLocal.cu
+++ b/lib/THCUNN/SpatialConvolutionLocal.cu
@@ -16,7 +16,7 @@ void THNN_CudaSpatialConvolutionLocal_updateOutput(
     long inputWidth, long inputHeight,
     long outputWidth, long outputHeight)
 {
-  THNN_assertSameGPU(state, 5, input, output, weight,
+  THCUNN_assertSameGPU(state, 5, input, output, weight,
                                  bias, finput);
 
   long nInputPlane = THCudaTensor_size(state,weight,2)/(kW*kH);
@@ -124,7 +124,7 @@ void THNN_CudaSpatialConvolutionLocal_updateGradInput(
     long inputWidth, long inputHeight,
     long outputWidth, long outputHeight)
 {
-  THNN_assertSameGPU(state, 5, input, gradOutput, weight,
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                                  fgradInput, gradInput);
 
   long nInputPlane = THCudaTensor_size(state,weight,2)/(kW*kH);
@@ -235,7 +235,7 @@ void THNN_CudaSpatialConvolutionLocal_accGradParameters(
     long outputWidth, long outputHeight,
     float scale)
 {
-  THNN_assertSameGPU(state, 5, input, gradOutput, gradWeight,
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, gradWeight,
                                  gradBias, finput);
 
   long nInputPlane = THCudaTensor_size(state,gradWeight,2)/(kW*kH);

--- a/lib/THCUNN/SpatialConvolutionMM.cu
+++ b/lib/THCUNN/SpatialConvolutionMM.cu
@@ -5,7 +5,7 @@
 
 void THNN_CudaSpatialConvolutionMM_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, THCudaTensor *weight, THCudaTensor *bias, THCudaTensor *columns, THCudaTensor *ones, int kW, int kH, int dW, int dH, int padW, int padH) {
 
-  THNN_assertSameGPU(state, 6, input, output, weight,
+  THCUNN_assertSameGPU(state, 6, input, output, weight,
                                  bias, columns, ones);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
   THArgCheck(weight->nDimension == 2, 4, "weight tensor must be 2D (nOutputPlane,nInputPlane*kH*kW)");
@@ -123,7 +123,7 @@ void THNN_CudaSpatialConvolutionMM_updateOutput(THCState *state, THCudaTensor *i
 
 void THNN_CudaSpatialConvolutionMM_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *weight, THCudaTensor *bias, THCudaTensor *gradColumns, THCudaTensor *ones, int kW, int kH, int dW, int dH, int padW, int padH) {
 
-  THNN_assertSameGPU(state, 5, input, gradOutput, weight,
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
   THArgCheck(weight->nDimension == 2, 4, "weight tensor must be 2D (nOutputPlane,nInputPlane*kH*kW)");
@@ -208,7 +208,7 @@ void THNN_CudaSpatialConvolutionMM_updateGradInput(THCState *state, THCudaTensor
 
 void THNN_CudaSpatialConvolutionMM_accGradParameters(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradWeight, THCudaTensor *gradBias, THCudaTensor *columns, THCudaTensor *ones, int kW, int kH, int dW, int dH, int padW, int padH, float scale) {
 
-  THNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
+  THCUNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
                                  gradBias, columns, ones);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
   THArgCheck(gradWeight->nDimension == 2, 4, "gradWeight tensor must be 2D (nOutputPlane,nInputPlane*kH*kW)");

--- a/lib/THCUNN/SpatialFullConvolution.cu
+++ b/lib/THCUNN/SpatialFullConvolution.cu
@@ -19,7 +19,7 @@ void THNN_CudaSpatialFullConvolution_updateOutput(
   int nInputPlane = THCudaTensor_size(state, weight, 0);
   int nOutputPlane = THCudaTensor_size(state, weight, 1);
 
-  THNN_assertSameGPU(state, 6, input, output, weight,
+  THCUNN_assertSameGPU(state, 6, input, output, weight,
                                  bias, columns, ones);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
 
@@ -139,7 +139,7 @@ void THNN_CudaSpatialFullConvolution_updateGradInput(
   int nInputPlane = THCudaTensor_size(state, weight, 0);
   int nOutputPlane = THCudaTensor_size(state, weight, 1);
 
-  THNN_assertSameGPU(state, 5, input, gradOutput, weight,
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
 
@@ -234,7 +234,7 @@ void THNN_CudaSpatialFullConvolution_accGradParameters(
   int nInputPlane = THCudaTensor_size(state, gradWeight, 0);
   int nOutputPlane = THCudaTensor_size(state, gradWeight, 1);
 
-  THNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
+  THCUNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
                                  gradBias, columns, ones);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
 

--- a/lib/THCUNN/SpatialMaxPooling.cu
+++ b/lib/THCUNN/SpatialMaxPooling.cu
@@ -75,7 +75,7 @@ __global__ void MaxPoolBackward(const int nthreads, const Dtype* top_diff,
 void THNN_CudaSpatialMaxPooling_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, THCudaTensor *indices, int kW, int kH, int dW, int dH, int padW, int padH, bool ceil_mode)
 {
 
-  THNN_assertSameGPU(state, 3, input, output, indices);
+  THCUNN_assertSameGPU(state, 3, input, output, indices);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch) tensor expected");
 
   long nInputCols, nInputRows, nInputPlane, batchSize;
@@ -147,7 +147,7 @@ void THNN_CudaSpatialMaxPooling_updateOutput(THCState *state, THCudaTensor *inpu
 
 void THNN_CudaSpatialMaxPooling_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *indices, int kW, int kH, int dW, int dH, int padW, int padH, bool ceil_mode)
 {
-  THNN_assertSameGPU(state, 4, input, gradOutput, indices, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, indices, gradInput);
 
   input = THCudaTensor_newContiguous(state, input);
   gradOutput = THCudaTensor_newContiguous(state, gradOutput);

--- a/lib/THCUNN/SpatialMaxUnpooling.cu
+++ b/lib/THCUNN/SpatialMaxUnpooling.cu
@@ -29,7 +29,7 @@ __global__ void MaxUnpoolBackward(const int nthreads, const Dtype* top_diff, con
 
 void THNN_CudaSpatialMaxUnpooling_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, THCudaTensor *indices, int owidth, int oheight)
 {
-  THNN_assertSameGPU(state, 3, input, output, indices);
+  THCUNN_assertSameGPU(state, 3, input, output, indices);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch) tensor expected");
 
   long nInputCols, nInputRows, nInputPlane, batchSize;
@@ -74,7 +74,7 @@ void THNN_CudaSpatialMaxUnpooling_updateOutput(THCState *state, THCudaTensor *in
 
 void THNN_CudaSpatialMaxUnpooling_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *indices, int owidth, int oheight)
 {
-  THNN_assertSameGPU(state, 4, input, gradOutput, indices, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, indices, gradInput);
 
   long nInputCols, nInputRows, nInputPlane, batchSize;
 

--- a/lib/THCUNN/SpatialSubSampling.cu
+++ b/lib/THCUNN/SpatialSubSampling.cu
@@ -250,7 +250,7 @@ void THNN_CudaSpatialSubSampling_updateOutput(THCState *state, THCudaTensor *inp
 
   int nInputPlane = THCudaTensor_size(state, weight, 0);
 
-  THNN_assertSameGPU(state, 4, input, output, weight, bias);
+  THCUNN_assertSameGPU(state, 4, input, output, weight, bias);
   THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch) tensor expected");
 
   if (input->nDimension == 3) {
@@ -319,7 +319,7 @@ void THNN_CudaSpatialSubSampling_updateOutput(THCState *state, THCudaTensor *inp
 
 void THNN_CudaSpatialSubSampling_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *weight, int kW, int kH, int dW, int dH)
 {
-  THNN_assertSameGPU(state, 4, input, gradOutput, weight, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, weight, gradInput);
 
   int nInputPlane = THCudaTensor_size(state, weight, 0);
 
@@ -387,7 +387,7 @@ void THNN_CudaSpatialSubSampling_updateGradInput(THCState *state, THCudaTensor *
 
 void THNN_CudaSpatialSubSampling_accGradParameters(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradWeight, THCudaTensor *gradBias, int kW, int kH, int dW, int dH, float scale)
 {
-  THNN_assertSameGPU(state, 4, input, gradOutput, gradWeight, gradBias);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, gradWeight, gradBias);
 
   int nInputPlane = THCudaTensor_size(state, gradWeight, 0);
 

--- a/lib/THCUNN/SpatialUpSamplingNearest.cu
+++ b/lib/THCUNN/SpatialUpSamplingNearest.cu
@@ -62,7 +62,7 @@ void THNN_CudaSpatialUpSamplingNearest_updateOutput(THCState *state, THCudaTenso
 {
   THCudaTensor_zero(state, output);
 
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
 
   input = THCudaTensor_newContiguous(state, input);
   // This is for allocating output Tensor
@@ -137,7 +137,7 @@ __global__ void downscale(float *gradInput_data, float *gradOutput_data, long no
 
 void THNN_CudaSpatialUpSamplingNearest_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, int scale_factor)
 {
-  THNN_assertSameGPU(state, 2, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 2, gradOutput, gradInput);
 
   THCudaTensor_zero(state, gradInput);
 

--- a/lib/THCUNN/Sqrt.cu
+++ b/lib/THCUNN/Sqrt.cu
@@ -17,7 +17,7 @@ struct sqrtupdateOutput_functor
 
 void THNN_CudaSqrt_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output, float eps)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, sqrtupdateOutput_functor(eps));
 }
@@ -34,7 +34,7 @@ struct sqrtupdateGradInput_functor
 
 void THNN_CudaSqrt_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, output);
   THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, sqrtupdateGradInput_functor());
 }

--- a/lib/THCUNN/Square.cu
+++ b/lib/THCUNN/Square.cu
@@ -11,7 +11,7 @@ struct squareupdateOutput_functor
 
 void THNN_CudaSquare_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, squareupdateOutput_functor());
 }
@@ -26,7 +26,7 @@ struct squareupdateGradInput_functor
 
 void THNN_CudaSquare_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput)
 {
-  THNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, input, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, input);
   THCudaTensor_pointwiseApply3(state, gradInput, input, gradOutput, squareupdateGradInput_functor());
 }

--- a/lib/THCUNN/Tanh.cu
+++ b/lib/THCUNN/Tanh.cu
@@ -11,7 +11,7 @@ struct tanhupdateOutput_functor
 
 void THNN_CudaTanh_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
   THCudaTensor_resizeAs(state, output, input);
   THCudaTensor_pointwiseApply2(state, output, input, tanhupdateOutput_functor());
 }
@@ -26,7 +26,7 @@ struct tanhupdateGradInput_functor
 
 void THNN_CudaTanh_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput, THCudaTensor *gradInput, THCudaTensor *output)
 {
-  THNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 3, output, gradOutput, gradInput);
   THCudaTensor_resizeAs(state, gradInput, output);
   THCudaTensor_pointwiseApply3(state, gradInput, output, gradOutput, tanhupdateGradInput_functor());
 }

--- a/lib/THCUNN/TemporalConvolution.cu
+++ b/lib/THCUNN/TemporalConvolution.cu
@@ -18,7 +18,7 @@ void THNN_CudaTemporalConvolution_updateOutput(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
 
-  THNN_assertSameGPU(state, 4, input, output, weight, bias);
+  THCUNN_assertSameGPU(state, 4, input, output, weight, bias);
   THArgCheck( input->nDimension == 2 || input->nDimension == 3, 2, "2D or 3D(batch mode) tensor expected");
 
   if (input->nDimension == 3)
@@ -147,7 +147,7 @@ void THNN_CudaTemporalConvolution_updateGradInput(
 
   int dimS = 0; // sequence dimension
 
-  THNN_assertSameGPU(state, 4, input, gradOutput, weight, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, weight, gradInput);
 
   if (gradOutput->nDimension == 3)
   {

--- a/lib/THCUNN/TemporalMaxPooling.cu
+++ b/lib/THCUNN/TemporalMaxPooling.cu
@@ -94,7 +94,7 @@ void THNN_CudaTemporalMaxPooling_updateOutput(
   float *output_data;
   float *indices_data;
 
-  THNN_assertSameGPU(state, 3, input, output, indices);
+  THCUNN_assertSameGPU(state, 3, input, output, indices);
   THArgCheck( input->nDimension == 2 || input->nDimension == 3, 2, "2D or 3D(batch mode) tensor expected");
 
   if (input->nDimension == 3)
@@ -169,7 +169,7 @@ void THNN_CudaTemporalMaxPooling_updateGradInput(
   float *gradOutput_data;
   float *indices_data;
 
-  THNN_assertSameGPU(state, 4, input, gradOutput, gradInput, indices);
+  THCUNN_assertSameGPU(state, 4, input, gradOutput, gradInput, indices);
   THArgCheck( input->nDimension == 2 || input->nDimension == 3, 2, "2D or 3D(batch mode) tensor expected");
 
   THCudaTensor_resizeAs(state, gradInput, input);

--- a/lib/THCUNN/Threshold.cu
+++ b/lib/THCUNN/Threshold.cu
@@ -38,7 +38,7 @@ struct ThresholdUpdateOutputIP
 void THNN_CudaThreshold_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output,
   double threshold, double val, bool inplace)
 {
-  THNN_assertSameGPU(state, 2, input, output);
+  THCUNN_assertSameGPU(state, 2, input, output);
 
   if (inplace)
   {
@@ -91,7 +91,7 @@ struct ThresholdUpdateGradInputIP
 void THNN_CudaThreshold_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *gradOutput,
   THCudaTensor *gradInput, double threshold, bool inplace)
 {
-  THNN_assertSameGPU(state, 3, input, gradInput, gradOutput);
+  THCUNN_assertSameGPU(state, 3, input, gradInput, gradOutput);
 
   if (inplace)
   {

--- a/lib/THCUNN/VolumetricConvolution.cu
+++ b/lib/THCUNN/VolumetricConvolution.cu
@@ -160,7 +160,7 @@ void THNN_CudaVolumetricConvolution_updateOutput(
 {
   THCudaTensor *columns = finput;
   THCudaTensor *ones = fgradInput;
-  THNN_assertSameGPU(state, 6, input, output, weight, bias, columns, ones);
+  THCUNN_assertSameGPU(state, 6, input, output, weight, bias, columns, ones);
 
   THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
     "4D or 5D (batch mode) tensor is expected"
@@ -303,7 +303,7 @@ void THNN_CudaVolumetricConvolution_updateGradInput(
 
   THCudaTensor *gradColumns = finput;
 
-  THNN_assertSameGPU(state, 5, input, gradOutput, weight, gradColumns, gradInput);
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, weight, gradColumns, gradInput);
   THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
     "4D or 5D (batch mode) tensor is expected"
   );
@@ -401,7 +401,7 @@ void THNN_CudaVolumetricConvolution_accGradParameters(
 {
   THCudaTensor *columns = finput;
   THCudaTensor *ones = fgradInput;
-  THNN_assertSameGPU(state, 6, input, gradOutput, gradWeight, gradBias, columns, ones);
+  THCUNN_assertSameGPU(state, 6, input, gradOutput, gradWeight, gradBias, columns, ones);
 
   THArgCheck(gradWeight->nDimension == 5, 4,
     "5D gradWeight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"

--- a/lib/THCUNN/VolumetricFullConvolution.cu
+++ b/lib/THCUNN/VolumetricFullConvolution.cu
@@ -25,7 +25,7 @@ void THNN_CudaVolumetricFullConvolution_updateOutput(
   const int kH           = (int)weight->size[3];
   const int kW           = (int)weight->size[4];
 
-  THNN_assertSameGPU(state, 6, input, output, weight,
+  THCUNN_assertSameGPU(state, 6, input, output, weight,
                                  bias, columns, ones);
   THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
 
@@ -152,7 +152,7 @@ void THNN_CudaVolumetricFullConvolution_updateGradInput(
   const int kH           = (int)weight->size[3];
   const int kW           = (int)weight->size[4];
 
-  THNN_assertSameGPU(state, 5, input, gradOutput, weight,
+  THCUNN_assertSameGPU(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
   THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
 
@@ -254,7 +254,7 @@ void THNN_CudaVolumetricFullConvolution_accGradParameters(
   const int kH           = (int)gradWeight->size[3];
   const int kW           = (int)gradWeight->size[4];
 
-  THNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
+  THCUNN_assertSameGPU(state, 6, input, gradOutput, gradWeight,
                                  gradBias, columns, ones);
   THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
 

--- a/lib/THCUNN/VolumetricMaxPooling.cu
+++ b/lib/THCUNN/VolumetricMaxPooling.cu
@@ -151,7 +151,7 @@ void THNN_CudaVolumetricMaxPooling_updateOutput(
   int outputHeight;
   int outputWidth;
 
-  THNN_assertSameGPU(state, 3, input, indices, output);
+  THCUNN_assertSameGPU(state, 3, input, indices, output);
 
   if (THCudaTensor_nDimension(state, input) == 4)
   {
@@ -333,7 +333,7 @@ void THNN_CudaVolumetricMaxPooling_updateGradInput(
   int outputHeight;
   int outputWidth;
 
-  THNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, indices, gradOutput, gradInput);
 
   if (THCudaTensor_nDimension(state, input) == 4) /* 4D */
   {

--- a/lib/THCUNN/common.h
+++ b/lib/THCUNN/common.h
@@ -5,7 +5,7 @@
 #define CUDA_KERNEL_LOOP(i, n) \
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); i += blockDim.x * gridDim.x)
 
-#define THNN_assertSameGPU(...) THAssertMsg(THCudaTensor_checkGPU(__VA_ARGS__), \
+#define THCUNN_assertSameGPU(...) THAssertMsg(THCudaTensor_checkGPU(__VA_ARGS__), \
   "Some of weight/gradient/input tensors are located on different GPUs. Please move them to a single one.")
 
 // Use 1024 threads per block, which requires cuda sm_2x or above


### PR DESCRIPTION
I have realised that I automatically wrote THNN prefix in `assertSameGPU`, while THNN has nothing to do with GPUs. It's purely a stylistic change, but it might save some time somebody searching for that macro in THNN. Sorry, I shouldn't commit when I'm tired :confused: