### PR TITLE
remove warnings about testsuite

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -1,4 +1,4 @@
-local cunntest = {}
+local cunntest = torch.TestSuite()
 local precision_forward = 1e-4
 local precision_backward = 1e-2
 local nloop = 1
@@ -4370,17 +4370,6 @@ function cunntest.VolumetricFullConvolution()
     end
 end
 
-function cunntest.getParameters()
-   -- smoke test for getParameters
-   local model = nn.Sequential()
-   model:add( nn.SpatialConvolution(1,10,3,3) )
-   model:add( nn.SpatialConvolution(10,20,3,3) )
-   model:cuda()
-   local weights, gradients = model:getParameters()
-   local copy = model:clone():float():cuda()
-   local weights, gradients = copy:getParameters()
-end
-
 function cunntest.LookupTable_forward()
    local nVocab = 10000
    local nDim = 100
@@ -4706,8 +4695,8 @@ local function setUp()
    cutorch.setDevice(1)
 end
 
-for k,v in pairs(cunntest) do
-   cunntest[k] = function()
+for k,v in pairs(cunntest.__tests) do
+   cunntest.__tests[k] = function()
       setUp()
       v()
    end


### PR DESCRIPTION
remove warnings about testsuite

Before:

```
Completed 567 asserts in 134 tests with 0 failures and 1 error and 1 warning
--------------------------------------------------------------------------------
distkldiv
 Function call failed
...tu/torch/install/share/lua/5.1/nn/DistKLDivCriterion.lua:9: input and target 
should have the same size
stack traceback:
        [C]: in function 'assert'
        ...tu/torch/install/share/lua/5.1/nn/DistKLDivCriterion.lua:9: in functi
on 'forward'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:2954: in function
 'v'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4712: in function
 </home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4710>
        [C]: in function 'xpcall'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:475: in functi
on '_pcall'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:435: in functi
on '_run'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:354: in functi
on 'run'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4732: in function
 'testcuda'
        (command line):1: in main chunk
        [C]: at 0x00406670

--------------------------------------------------------------------------------
Should use TestSuite rather than plain lua table

--------------------------------------------------------------------------------
luajit: /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:362: An error 
was found while running tests!
stack traceback:
        [C]: in function 'assert'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:362: in functi
on 'run'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4732: in function
 'testcuda'
        (command line):1: in main chunk
        [C]: at 0x00406670
```

After:
```
Completed 567 asserts in 134 tests with 1 failure and 1 error
--------------------------------------------------------------------------------
distkldiv
 Function call failed
...tu/torch/install/share/lua/5.1/nn/DistKLDivCriterion.lua:9: input and target should have the same size
stack traceback:
        [C]: in function 'assert'
        ...tu/torch/install/share/lua/5.1/nn/DistKLDivCriterion.lua:9: in function 'forward'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:2954: in function 'v'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4701: in function </home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4699>
        [C]: in function 'xpcall'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:475: in function '_pcall'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:435: in function '_run'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:354: in function 'run'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4721: in function 'testcuda'
        (command line):1: in main chunk
        [C]: at 0x00406670

--------------------------------------------------------------------------------
ELU_transposed
error on state (backward) 
LT failed: 1.1920928955078e-07 >= 1e-07
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:268: in function 'v'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4701: in function </home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4699>
--------------------------------------------------------------------------------
luajit: /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:362: An error was found while running tests!
stack traceback:
        [C]: in function 'assert'
        /home/ubuntu/torch/install/share/lua/5.1/torch/Tester.lua:362: in function 'run'
        /home/ubuntu/torch/install/share/lua/5.1/cunn/test.lua:4721: in function 'testcuda'
        (command line):1: in main chunk
        [C]: at 0x00406670
```