### PR TITLE
Add alias cunn.test(), following eg format of cutorch.test()

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -4743,3 +4743,8 @@ function nn.testcuda(tests, print_timing, n_loop, seed)
        print ' ------------------------------------------------------------------------------------------------'
    end
 end
+
+-- add alias, in same format as eg cutorch.test()
+cunn = cunn or {}
+cunn.test = nn.testcuda
+


### PR DESCRIPTION
Add alias cunn.test(), following eg format of cutorch.test()

(Cos, so many times I type like:

```
luajit -l cunn -e 'cunn.test()'
-- hmmm, nope...
luajit -l cunn -e 'nn.cudatest()'
-- hmmm....
vim ~/torch/install/share/lua/5.1/cunn/test.lua
-- fine ...
luajit -l cunn -e 'nn.testcuda()'
```
)