### PR TITLE
Add SpatialClassNLLCriterion

### DIFF
--- a/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -1,0 +1,233 @@
+#include "THCUNN.h"
+#include "common.h"
+
+#include <stdio.h>
+#include <assert.h>
+
+// No love for C++11?
+//static_assert(CUDA_NUM_THREADS == CUDA_WARP_SIZE * CUDA_WARP_SIZE,
+//                "SpatialClassNLLCriterion_updateOutput kernel assumes that" \
+//                "number of used threads is a square of warp size");
+
+static const int NWARPS = CUDA_NUM_THREADS / CUDA_WARP_SIZE;
+
+__inline__ __device__ float warpReduceSum(float val) {
+  for (int offset = CUDA_WARP_SIZE/2; offset > 0; offset /= 2)
+    val += __shfl_down(val, offset);
+  return val;
+}
+
+__global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
+          float *output,
+          float *total_weight,
+          float *input,
+          float *target,
+          float *weights,
+          int size_average,
+          int batch_size,
+          int n_classes,
+          int map_nelem,
+          int blocks_per_sample)
+{
+  __shared__ float partial_sums[NWARPS], partial_weight_sums[NWARPS];
+
+  int i, t;
+  int warp_idx = threadIdx.x / CUDA_WARP_SIZE;
+  int thread_idx = threadIdx.x % CUDA_WARP_SIZE;
+  float cur_weight;
+  float input_sum = 0;
+  float acc_weight = 0;
+
+  int sample = blockIdx.x / blocks_per_sample;
+  int toffset = sample * map_nelem;
+  int ioffset = sample * map_nelem * n_classes;
+  int step = blockDim.x * blocks_per_sample;
+  for (i = (blockIdx.x % blocks_per_sample) * blockDim.x + threadIdx.x;
+       i < map_nelem;
+       i += step) {
+    t = target[toffset + i] - 1;
+    assert(t >= 0 && t < n_classes);
+    cur_weight = weights ? weights[t] : 1.0f;
+    input_sum -= input[ioffset + i + map_nelem * t] * cur_weight;
+    acc_weight += cur_weight;
+  }
+
+  // not sure about this one - __shfl_down has some synchronization built in
+  __syncthreads();
+
+  input_sum = warpReduceSum(input_sum);
+  if (thread_idx == 0)
+    partial_sums[warp_idx] = input_sum;
+
+  acc_weight = warpReduceSum(acc_weight);
+  if (thread_idx == 0)
+    partial_weight_sums[warp_idx] = acc_weight;
+
+  __syncthreads();
+
+  if (warp_idx == 0) {
+    input_sum = partial_sums[thread_idx];
+    acc_weight = partial_weight_sums[thread_idx];
+
+    input_sum = warpReduceSum(input_sum);
+    acc_weight = warpReduceSum(acc_weight);
+
+    if (thread_idx == 0) {
+      atomicAdd(total_weight, acc_weight);
+      if (size_average && acc_weight > 0)
+        atomicAdd(output, input_sum / acc_weight / gridDim.x);
+      else
+        atomicAdd(output, input_sum);
+    }
+  }
+}
+
+__global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
+          float *gradInput,
+          float *target,
+          float *weights,
+          float *total_weight,
+          int size_average,
+          int batch_size,
+          int n_classes,
+          int map_nelem,
+          int blocks_per_sample)
+{
+  if (*total_weight <= 0)
+    return;
+
+  int i, t;
+  float norm = size_average ? (1.0f / *total_weight) : 1.0f;
+
+  int sample = blockIdx.x / blocks_per_sample;
+  int step = blockDim.x * blocks_per_sample;
+  int toffset = sample * map_nelem;
+  int ioffset = sample * map_nelem * n_classes;
+  for (i = (blockIdx.x % blocks_per_sample) * blockDim.x + threadIdx.x;
+       i < map_nelem;
+       i += step) {
+    t = (int)target[toffset + i] - 1;
+    assert(t >= 0 && t < n_classes);
+    gradInput[ioffset + i + map_nelem * t] = -(weights ? weights[t] : 1.0f) * norm;
+  }
+}
+
+void THNN_CudaSpatialClassNLLCriterion_updateOutput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *output,
+          bool sizeAverage,
+          THCudaTensor *weights,
+          THCudaTensor *total_weight)
+{
+  THArgCheck(THCudaTensor_nDimension(state, target) == 3, 1,
+               "only batches of spatial targets supported (3D tensors)");
+  THArgCheck(THCudaTensor_nDimension(state, input) == 4, 2,
+               "only batches of spatial inputs supported (4D tensors)");
+
+  if (weights)
+    THCUNN_assertSameGPU(state, 5, input, target, weights, output, total_weight);
+  else
+    THCUNN_assertSameGPU(state, 4, input, target, output, total_weight);
+
+  input = THCudaTensor_newContiguous(state, input);
+  weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
+  target = THCudaTensor_newContiguous(state, target);
+
+  float *input_data = THCudaTensor_data(state, input);
+  float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
+  float *target_data = THCudaTensor_data(state, target);
+  float *output_data = THCudaTensor_data(state, output);
+  float *total_weight_data = THCudaTensor_data(state, total_weight);
+
+  long batch_size = THCudaTensor_size(state, target, 0);
+  long map_nelem = THCudaTensor_nElement(state, target) / batch_size;
+  int blocks_per_sample = GET_BLOCKS(map_nelem) / 128;
+  blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
+  int total_blocks = blocks_per_sample * batch_size;
+
+  THCudaTensor_fill(state, output, 0);
+  THCudaTensor_fill(state, total_weight, 0);
+
+  cunn_SpatialClassNLLCriterion_updateOutput_kernel
+    <<<total_blocks, CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      output_data,
+      total_weight_data,
+      input_data,
+      target_data,
+      weights_data,
+      sizeAverage,
+      THCudaTensor_size(state, input, 0),
+      THCudaTensor_size(state, input, 1),
+      THCudaTensor_size(state, input, 2) * THCudaTensor_size(state, input, 3),
+      blocks_per_sample
+  );
+
+  cudaError errcode = cudaGetLastError();
+  if (errcode != cudaSuccess) {
+    THError(cudaGetErrorString(errcode));
+  }
+  if (weights)
+    THCudaTensor_free(state, weights);
+  THCudaTensor_free(state, target);
+  THCudaTensor_free(state, input);
+}
+
+void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *gradInput,
+          bool sizeAverage,
+          THCudaTensor *weights,
+          THCudaTensor *total_weight)
+{
+  THArgCheck(THCudaTensor_nDimension(state, target) == 3, 1,
+               "only batches of spatial targets supported (3D tensors)");
+  THArgCheck(THCudaTensor_nDimension(state, input) == 4, 2,
+               "only batches of spatial inputs supported (4D tensors)");
+  THArgCheck(THCudaTensor_isContiguous(state, gradInput), 4,
+               "gradInput must be contiguous");
+
+  if (weights)
+    THCUNN_assertSameGPU(state, 5, weights, input, target, gradInput, total_weight);
+  else
+    THCUNN_assertSameGPU(state, 4, input, target, gradInput, total_weight);
+
+  input = THCudaTensor_newContiguous(state, input);
+  weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
+  target = THCudaTensor_newContiguous(state, target);
+
+  float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
+  float *gradInput_data = THCudaTensor_data(state, gradInput);
+  float *target_data = THCudaTensor_data(state, target);
+  float *total_weight_data = THCudaTensor_data(state, total_weight);
+
+  long batch_size = THCudaTensor_size(state, target, 0);
+  long map_nelem = THCudaTensor_nElement(state, target) / batch_size;
+  int blocks_per_sample = GET_BLOCKS(map_nelem) / 128;
+  blocks_per_sample = (blocks_per_sample == 0) ? 1 : blocks_per_sample;
+  int total_blocks = blocks_per_sample * batch_size;
+
+  cunn_SpatialClassNLLCriterion_updateGradInput_kernel
+    <<<total_blocks, CUDA_NUM_THREADS, 0, THCState_getCurrentStream(state)>>>(
+      gradInput_data,
+      target_data,
+      weights_data,
+      total_weight_data,
+      sizeAverage,
+      THCudaTensor_size(state, input, 0),
+      THCudaTensor_size(state, input, 1),
+      THCudaTensor_size(state, input, 2) *THCudaTensor_size(state, input, 3),
+      blocks_per_sample
+  );
+  cudaError errcode = cudaGetLastError();
+  if (errcode != cudaSuccess) {
+    THError(cudaGetErrorString(errcode));
+  }
+  if (weights)
+    THCudaTensor_free(state, weights);
+  THCudaTensor_free(state, target);
+  THCudaTensor_free(state, input);
+}

--- a/lib/THCUNN/THCUNN.h
+++ b/lib/THCUNN/THCUNN.h
@@ -47,6 +47,23 @@ TH_API void THNN_CudaClassNLLCriterion_updateGradInput(
           THCudaTensor *weights,
           THCudaTensor *total_weight);
 
+TH_API void THNN_CudaSpatialClassNLLCriterion_updateOutput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *output,
+          bool sizeAverage,
+          THCudaTensor *weights,
+          THCudaTensor *total_weight);
+TH_API void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *gradInput,
+          bool sizeAverage,
+          THCudaTensor *weights,
+          THCudaTensor *total_weight);
+
 TH_API void THNN_CudaDistKLDivCriterion_updateOutput(
           THCState *state,
           THCudaTensor *input,

--- a/lib/THCUNN/common.h
+++ b/lib/THCUNN/common.h
@@ -11,6 +11,8 @@
 // Use 1024 threads per block, which requires cuda sm_2x or above
 const int CUDA_NUM_THREADS = 1024;
 
+const int CUDA_WARP_SIZE = 32;
+
 // CUDA: number of blocks for threads.
 inline int GET_BLOCKS(const int N)
 {

--- a/test.lua
+++ b/test.lua
@@ -3551,6 +3551,42 @@ function cunntest.ClassNLLCriterionMultipleTarget()
    mytester:assertlt(gerr:abs():max(), precision_forward, 'error  on gradInput')
 end
 
+function cunntest.SpatialClassNLLCriterion()
+   local batchSize = math.random(5, 10)
+   local h = math.random(300, 500)
+   local w = math.random(300, 800)
+   local classes = math.random(10,30)
+   local input = torch.randn(batchSize, classes, h, w)
+   local target = torch.Tensor(batchSize, h, w)
+   target:apply(function() return math.random(1, classes) end)
+   local mod = nn.SpatialClassNLLCriterion()
+
+   local tm = {}
+   local title = string.format('SpatialClassNLLCriterion %dx%dx%dx%d ',
+         batchSize, classes, h, w)
+   times[title] = tm
+
+   local a = torch.Timer()
+   local fout = mod:forward(input, target)
+   local fgin = mod:backward(input, target):clone()
+   tm.cpu = a:time().real
+
+   local cinput = input:cuda()
+   local ctarget = target:cuda()
+
+   local cmod = nn.SpatialClassNLLCriterion():cuda()
+   a:reset()
+   local cout = cmod:forward(cinput,ctarget)
+   local cgin = cmod:backward(cinput,ctarget)
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   mytester:assertlt(
+       math.abs(fout-cout), precision_forward, 'error on output')
+
+   local gerr = cgin:float() - fgin
+   mytester:assertlt(gerr:abs():max(), precision_forward, 'error  on gradInput')
+end
 
 function cunntest.ClassNLLCriterionMultipleTargetWeights()
    local size = math.random(3000,5000)


### PR DESCRIPTION
Original `ClassNLLCriterion` is awfully slow when it comes to spatial data. It forces you to transpose it to a 2D Tensor (NCHW -> NHWC), which is pretty expensive by itself for big tensors, and then it uses a **hardcoded number of 32 threads** for processing (e.g. 1M elements)... This means that around 80% of my training loop is spent doing criterion stuff.

Here is a nice comparison from visual profiler:
<img width="581" alt="screen shot 2016-04-14 at 21 52 22" src="https://cloud.githubusercontent.com/assets/4583066/14541741/b6289700-028b-11e6-884e-bc5a2b648d57.png">
On the left 100x fw+bw pass of SpatialClassNLLCriterion, on the right 1 fw+bw of ClassNLLCriterion (not including transpose).

These are the times for `4x20x512x1024` input and `4x512x1024` targets (100 runs):

| Criterion                                      | Time for 100 runs (s) |
|------------------------------------------------|-----------------------|
| SpatialClassNLLCriterion                       | 0.15400      |
| ClassNLLCriterion                              | 4.03642       |
| Transpose + ClassNLLCriterion + Transpose back | 21.66718       |

If you agree to merge this module here I will also provide Lua code and write a CPU version for `nn`. This can speed up `cudnn.SpatialCrossEntropyCriterion` significantly.