### PR TITLE
Fix clearState in DataParallelTable

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -105,16 +105,16 @@ function DataParallelTable:flattenParameters()
       local p, dp = module:parameters()
       local flattened = true
       for i=2,#p do
-         if p[i]:storage() ~= p[1]:storage() 
+         if p[i]:storage() ~= p[1]:storage()
             or dp[i]:storage() ~= dp[1]:storage() then
             flattened = false
             break
          end
       end
       if flattened then
-         local pp = torch.CudaTensor(p[1]:storage(), p[1]:storageOffset(), 
+         local pp = torch.CudaTensor(p[1]:storage(), p[1]:storageOffset(),
                     p[#p]:storageOffset()+p[#p]:numel()-1)
-         local dpp = torch.CudaTensor(dp[1]:storage(), dp[1]:storageOffset(), 
+         local dpp = torch.CudaTensor(dp[1]:storage(), dp[1]:storageOffset(),
                      dp[#dp]:storageOffset()+dp[#dp]:numel()-1)
          return {pp, dpp}
       else
@@ -159,7 +159,7 @@ function DataParallelTable:clearState()
    self.impl:exec(function(module)
       module:clearState()
    end)
-   parent.clearState(self)
+   return parent.clearState(self)
 end
 
 


### PR DESCRIPTION
Make it return the module, just like all other modules do.