### PR TITLE
add WeightedClassNLLCriterion and WeightedSmoothL1Criterion

### DIFF
--- a/lib/THCUNN/THCUNN.h
+++ b/lib/THCUNN/THCUNN.h
@@ -47,6 +47,23 @@ TH_API void THNN_CudaClassNLLCriterion_updateGradInput(
           THCudaTensor *weights,
           THCudaTensor *total_weight);
 
+TH_API void THNN_CudaWeightedClassNLLCriterion_updateOutput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *output,
+          bool sizeAverage,
+          THCudaTensor *weights,
+          THCudaTensor *total_weight);
+TH_API void THNN_CudaWeightedClassNLLCriterion_updateGradInput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *gradInput,
+          bool sizeAverage,
+          THCudaTensor *weights,
+          THCudaTensor *total_weight);
+
 TH_API void THNN_CudaSpatialClassNLLCriterion_updateOutput(
           THCState *state,
           THCudaTensor *input,
@@ -316,6 +333,23 @@ TH_API void THNN_CudaSmoothL1Criterion_updateGradInput(
           THCudaTensor *target,
           THCudaTensor *gradInput,
           bool sizeAverage);
+
+TH_API void THNN_CudaWeightedSmoothL1Criterion_updateOutput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *output,
+          bool sizeAverage, 
+          THCudaTensor *weights,
+          THCudaTensor *total_weight);
+TH_API void THNN_CudaWeightedSmoothL1Criterion_updateGradInput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *gradInput,
+          bool sizeAverage, 
+          THCudaTensor *weights,
+          THCudaTensor *total_weight);
 
 TH_API void THNN_CudaSoftMax_updateOutput(
           THCState *state,

--- a/lib/THCUNN/WeightedClassNLLCriterion.cu
+++ b/lib/THCUNN/WeightedClassNLLCriterion.cu
@@ -1,0 +1,244 @@
+#include "THCUNN.h"
+#include "common.h"
+
+#include <stdio.h>
+#include <assert.h>
+
+static const int NTHREADS = 32;
+
+__global__ void cunn_WeightedClassNLLCriterion_updateOutput_kernel1(float *output,
+                                                           float *total_weight,
+                                                           float *input,
+                                                           float *target,
+                                                           float *weights,
+                                                           int size_average,
+                                                           int n_classes) {
+  assert(threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0);
+
+  // TODO: T4951791 Reuse code between updateOutput_kernel1 and
+  // updateOutput_kernel.
+
+  int t = (int)*target - 1;
+  assert(t >= 0 && t < n_classes);
+  float cur_weight = weights ? weights[0] : 1.0f;
+  *output = -cur_weight * input[t];
+  *total_weight = cur_weight;
+  if (size_average && *total_weight > 0) {
+    *output /= *total_weight;
+  }
+}
+
+__global__ void cunn_WeightedClassNLLCriterion_updateOutput_kernel(float *output,
+                                                           float *total_weight,
+                                                           float *input,
+                                                           float *target,
+                                                           float *weights,
+                                                           int size_average,
+                                                           int nframe,
+                                                           int ndim,
+                                                           int n_classes) {
+  __shared__ float shInputs[NTHREADS], acc_weight[NTHREADS];
+  int i, t;
+  float cur_weight;
+
+  shInputs[threadIdx.x] = 0.0f;
+  acc_weight[threadIdx.x] = 0.0f;
+  for (i = threadIdx.x; i < nframe; i += NTHREADS) {
+      t = target[i] - 1;
+      assert(t >= 0 && t < n_classes);
+      cur_weight = weights ? weights[i] : 1.0f;
+      shInputs[threadIdx.x] -= input[i * ndim + t] * cur_weight;
+      acc_weight[threadIdx.x] += cur_weight;
+  }
+  __syncthreads();
+
+  // TODO: T4951791 Reuse code between updateOutput_kernel1 and
+  // updateOutput_kernel
+
+  if (threadIdx.x == 0) {
+    *output = *total_weight = 0;
+    for (i = 0; i < NTHREADS; ++i){
+      *output += shInputs[i];
+      *total_weight += acc_weight[i];
+    }
+    if (size_average && *total_weight > 0) {
+      *output /= *total_weight;
+    }
+  }
+}
+
+__global__ void cunn_WeightedClassNLLCriterion_updateGradInput_kernel1(
+  float* gradInput,
+  float* weights,
+  float* target,
+  float* total_weight,
+  int size_average,
+  int n_classes)
+{
+  if (*total_weight <= 0) {
+    return;
+  }
+  float norm = size_average ? (1.0f / *total_weight) : 1.0f;
+  int t = (int)*target - 1;
+  assert(t >= 0 && t < n_classes);
+  gradInput[t] = -(weights ? weights[0] : 1.0f) * norm;
+}
+
+__global__ void cunn_WeightedClassNLLCriterion_updateGradInput_kernel(
+  float *gradInput,
+  float *target,
+  float *weights,
+  float *total_weight,
+  int size_average,
+  int nframe,
+  int ndim,
+  int n_classes)
+{
+  if (*total_weight <= 0) {
+    return;
+  }
+  int i, t;
+  float norm = size_average ? (1.0f / *total_weight) : 1.0f;
+
+  for (i = threadIdx.x; i < nframe; i += NTHREADS) {
+    t = (int)target[i] - 1;
+    assert(t >= 0 && t < n_classes);
+    gradInput[i * ndim + t] = -(weights ? weights[i] : 1.0f) * norm;
+  }
+}
+
+void THNN_CudaWeightedClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights, THCudaTensor *total_weight) {
+  if (THCudaTensor_nDimension(state, target) > 1) {
+    THError("multi-target not supported");
+  }
+
+  int n_dims = THCudaTensor_nDimension(state, input);
+  int n_classes = THCudaTensor_size(state, input, n_dims - 1);
+
+  if (weights) {
+    THCUNN_assertSameGPU(
+      state, 5, input, target, weights, output, total_weight
+    );
+  } else {
+    THCUNN_assertSameGPU(
+      state, 4, input, target, output, total_weight
+    );
+  }
+
+  if (THCudaTensor_nDimension(state, input) > 2) {
+    THArgCheck(0, 2, "vector or matrix expected");
+  }
+
+  input = THCudaTensor_newContiguous(state, input);
+  weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
+  target = THCudaTensor_newContiguous(state, target);
+
+  float *input_data = THCudaTensor_data(state, input);
+  float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
+  float *target_data = THCudaTensor_data(state, target);
+  float *output_data = THCudaTensor_data(state, output);
+  float *total_weight_data = THCudaTensor_data(state, total_weight);
+
+  if (THCudaTensor_nDimension(state, input) == 1) {
+    cunn_WeightedClassNLLCriterion_updateOutput_kernel1
+      <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
+        output_data,
+        total_weight_data,
+        input_data,
+        target_data,
+        weights_data,
+        sizeAverage,
+        n_classes
+    );
+
+  } else if (THCudaTensor_nDimension(state, input) == 2) {
+    cunn_WeightedClassNLLCriterion_updateOutput_kernel
+      <<<1, NTHREADS, 0, THCState_getCurrentStream(state)>>>(
+        output_data,
+        total_weight_data,
+        input_data,
+        target_data,
+        weights_data,
+        sizeAverage,
+        THCudaTensor_size(state, input, 0),
+        THCudaTensor_size(state, input, 1),
+        n_classes
+    );
+  }
+
+  cudaError errcode = cudaGetLastError();
+  if (errcode != cudaSuccess) {
+    THError(cudaGetErrorString(errcode));
+  }
+  if (weights) {
+    THCudaTensor_free(state, weights);
+  }
+  THCudaTensor_free(state, target);
+  THCudaTensor_free(state, input);
+}
+
+void THNN_CudaWeightedClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights, THCudaTensor *total_weight) {
+  if (THCudaTensor_nDimension(state, target) > 1) {
+    THError("multi-target not supported");
+  }
+
+  int n_dims = THCudaTensor_nDimension(state, input);
+  int n_classes = THCudaTensor_size(state, input, n_dims - 1);
+
+  THArgCheck(THCudaTensor_isContiguous(state, gradInput), 4, "gradInput must be contiguous");
+
+  if (weights) {
+    THCUNN_assertSameGPU(
+      state, 5, weights, input, target, gradInput, total_weight
+    );
+  }
+  else {
+    THCUNN_assertSameGPU(
+      state, 4, input, target, gradInput, total_weight
+    );
+  }
+
+  if (THCudaTensor_nDimension(state, input) > 2) {
+    THArgCheck(0, 2, "vector or matrix expected");
+  }
+
+  weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
+  target = THCudaTensor_newContiguous(state, target);
+
+  float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
+  float *gradInput_data = THCudaTensor_data(state, gradInput);
+  float *target_data = THCudaTensor_data(state, target);
+  float *total_weight_data = THCudaTensor_data(state, total_weight);
+
+  if (THCudaTensor_nDimension(state, input) == 1) {
+    cunn_WeightedClassNLLCriterion_updateGradInput_kernel1
+      <<<1, 1, 0, THCState_getCurrentStream(state)>>>(
+        gradInput_data,
+        weights_data,
+        target_data,
+        total_weight_data,
+        sizeAverage,
+        n_classes
+    );
+  } else {
+    cunn_WeightedClassNLLCriterion_updateGradInput_kernel
+      <<<1, NTHREADS, 0, THCState_getCurrentStream(state)>>>(
+        gradInput_data,
+        target_data,
+        weights_data,
+        total_weight_data,
+        sizeAverage,
+        THCudaTensor_size(state, input, 0),
+        THCudaTensor_size(state, input, 1),
+        n_classes
+    );
+  }
+  cudaError errcode = cudaGetLastError();
+  if (errcode != cudaSuccess) {
+    THError(cudaGetErrorString(errcode));
+  }
+  if (weights) {
+    THCudaTensor_free(state, weights);
+  }
+  THCudaTensor_free(state, target);
+}

--- a/lib/THCUNN/WeightedSmoothL1Criterion.cu
+++ b/lib/THCUNN/WeightedSmoothL1Criterion.cu
@@ -1,0 +1,171 @@
+#include "THCUNN.h"
+#include "common.h"
+
+#include <stdio.h>
+#include <assert.h>
+
+static const int NTHREADS = 32;
+
+__global__ void cunn_WeightedSmoothL1Criterion_updateOutput_kernel(float *output,
+                                                           float *total_weight,
+                                                           float *input,
+                                                           float *target,
+                                                           float *weights,
+                                                           int size_average,
+                                                           int numel) {
+  __shared__ float shInputs[NTHREADS], acc_weight[NTHREADS];
+  int i;
+  float cur_weight;
+
+  shInputs[threadIdx.x] = 0.0f;
+  acc_weight[threadIdx.x] = 0.0f;
+  for (i = threadIdx.x; i < numel; i += NTHREADS) {
+      cur_weight = weights ? weights[i] : 1.0f;
+      float z = fabsf(input[i]-target[i]);
+      shInputs[threadIdx.x] += (z < 1.f ? 0.5f*z*z : z - 0.5f) * cur_weight;
+      acc_weight[threadIdx.x] += cur_weight;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    *output = *total_weight = 0;
+    for (i = 0; i < NTHREADS; ++i){
+      *output += shInputs[i];
+      *total_weight += acc_weight[i];
+    }
+    if (size_average && *total_weight > 0) {
+      *output /= *total_weight;
+    }
+  }
+}
+
+__global__ void cunn_WeightedSmoothL1Criterion_updateGradInput_kernel(
+  float *gradInput,
+  float *input, 
+  float *target,
+  float *weights,
+  float *total_weight,
+  int size_average,
+  int numel)
+{
+  if (*total_weight <= 0) {
+    return;
+  }
+  int i;
+  float norm = size_average ? (1.0f / *total_weight) : 1.0f;
+
+  for (i = threadIdx.x; i < numel; i += NTHREADS) {
+    float z = input[i] - target[i]; 
+    if (z < -1.f)
+      gradInput[i] = -(weights ? weights[i] : 1.0f) * norm;
+    else if (z > 1.f)
+      gradInput[i] = (weights ? weights[i] : 1.0f) * norm;
+    else
+      gradInput[i] = z * (weights ? weights[i] : 1.0f) * norm;
+  }
+}
+
+void THNN_CudaWeightedSmoothL1Criterion_updateOutput(
+    THCState *state, 
+    THCudaTensor *input, 
+    THCudaTensor *target, 
+    THCudaTensor *output, 
+    bool sizeAverage, 
+    THCudaTensor *weights, 
+    THCudaTensor *total_weight) {
+
+  if (weights) {
+    THCUNN_assertSameGPU(
+      state, 5, input, target, weights, output, total_weight
+    );
+  } else {
+    THCUNN_assertSameGPU(
+      state, 4, input, target, output, total_weight
+    );
+  }
+
+  input = THCudaTensor_newContiguous(state, input);
+  weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
+  target = THCudaTensor_newContiguous(state, target);
+
+  float *input_data = THCudaTensor_data(state, input);
+  float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
+  float *target_data = THCudaTensor_data(state, target);
+  float *output_data = THCudaTensor_data(state, output);
+  float *total_weight_data = THCudaTensor_data(state, total_weight);
+
+  cunn_WeightedSmoothL1Criterion_updateOutput_kernel
+    <<<1, NTHREADS, 0, THCState_getCurrentStream(state)>>>(
+      output_data,
+      total_weight_data,
+      input_data,
+      target_data,
+      weights_data,
+      sizeAverage,
+      THCudaTensor_nElement(state, input)
+  );
+
+  cudaError errcode = cudaGetLastError();
+  if (errcode != cudaSuccess) {
+    THError(cudaGetErrorString(errcode));
+  }
+  if (weights) {
+    THCudaTensor_free(state, weights);
+  }
+  THCudaTensor_free(state, target);
+  THCudaTensor_free(state, input);
+}
+
+void THNN_CudaWeightedSmoothL1Criterion_updateGradInput(
+    THCState *state, 
+    THCudaTensor *input, 
+    THCudaTensor *target, 
+    THCudaTensor *gradInput, 
+    bool sizeAverage, 
+    THCudaTensor *weights, 
+    THCudaTensor *total_weight) {
+
+  THArgCheck(THCudaTensor_isContiguous(state, gradInput), 4, "gradInput must be contiguous");
+
+  if (weights) {
+    THCUNN_assertSameGPU(
+      state, 5, weights, input, target, gradInput, total_weight
+    );
+  }
+  else {
+    THCUNN_assertSameGPU(
+      state, 4, input, target, gradInput, total_weight
+    );
+  }
+
+  input = THCudaTensor_newContiguous(state, input);
+  weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
+  target = THCudaTensor_newContiguous(state, target);
+
+  float *input_data = THCudaTensor_data(state, input);
+  float *weights_data = weights ? THCudaTensor_data(state, weights) : NULL;
+  float *gradInput_data = THCudaTensor_data(state, gradInput);
+  float *target_data = THCudaTensor_data(state, target);
+  float *total_weight_data = THCudaTensor_data(state, total_weight);
+
+  cunn_WeightedSmoothL1Criterion_updateGradInput_kernel
+    <<<1, NTHREADS, 0, THCState_getCurrentStream(state)>>>(
+      gradInput_data,
+      input_data,
+      target_data,
+      weights_data,
+      total_weight_data,
+      sizeAverage,
+      THCudaTensor_nElement(state, input)
+  );
+
+  cudaError errcode = cudaGetLastError();
+  if (errcode != cudaSuccess) {
+    THError(cudaGetErrorString(errcode));
+  }
+  if (weights) {
+    THCudaTensor_free(state, weights);
+  }
+  THCudaTensor_free(state, target);
+  THCudaTensor_free(state, input);
+}

--- a/test.lua
+++ b/test.lua
@@ -3266,6 +3266,39 @@ function cunntest.SmoothL1()
    end
 end
 
+function cunntest.WeightedSmoothL1Criterion()
+   for sizeAverage = 0, 1 do
+      local size = math.random(3000,5000)
+      local input = torch.randn(size,1,1)
+      local target = torch.randn(size)
+      local weights = torch.rand(size)
+      local mod = nn.WeightedSmoothL1Criterion(sizeAverage == 1)
+
+      local tm = {}
+      local title = string.format('WeightedSmoothL1Criterion sizeAverage %d, %d ', sizeAverage, size)
+      times[title] = tm
+
+      local a = torch.Timer()
+      local fout = mod:forward(input,{target, weights})
+      local fgin = mod:backward(input,{target, weights}):clone()
+      tm.cpu = a:time().real
+
+      local cinput = input:cuda()
+      local ctarget = target:cuda()
+      local cweights = weights:cuda()
+      local cmod = nn.WeightedSmoothL1Criterion(sizeAverage == 1):cuda()
+      a:reset()
+      local cout = cmod:forward(cinput,{ctarget, cweights})
+      local cgin = cmod:backward(cinput,{ctarget, cweights})
+      cutorch.synchronize()
+      tm.gpu = a:time().real
+
+      mytester:assertlt(math.abs(fout-cout), 0.01, 'error  on output')
+      local gerr = cgin:float() - fgin
+      mytester:assertlt(gerr:abs():max(), precision_forward, 'error  on gradInput')
+   end
+end
+
 function cunntest.SoftMarginCriterion()
    for sizeAverage = 0, 1 do
       local size = math.random(3000,5000)
@@ -3971,6 +4004,40 @@ function cunntest.ClassNLLCriterionMultipleTargetWeights()
    a:reset()
    local cout = cmod:forward(cinput,ctarget)
    local cgin = cmod:backward(cinput,ctarget)
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   mytester:assertlt(
+       math.abs(fout-cout), precision_forward, 'error on output')
+
+   local gerr = cgin:float() - fgin
+   mytester:assertlt(gerr:abs():max(), precision_forward, 'error  on gradInput')
+end
+
+function cunntest.WeightedClassNLLCriterionMultipleTargetWeights()
+   local size = math.random(3000,5000)
+   local input = torch.randn(size, size)
+   local target = torch.randperm(size)
+   local weights = torch.rand(size)
+   local mod = nn.WeightedClassNLLCriterion()
+
+   local tm = {}
+   local title = string.format('WeightedClassNLLCriterionMultiTargetWeights %d ',size)
+   times[title] = tm
+
+   local a = torch.Timer()
+   local fout = mod:forward(input, {target, weights})
+   local fgin = mod:backward(input, {target, weights}):clone()
+   tm.cpu = a:time().real
+
+   local cinput = input:cuda()
+   local ctarget = target:cuda()
+   local cweights = weights:cuda()
+
+   local cmod = nn.WeightedClassNLLCriterion():cuda()
+   a:reset()
+   local cout = cmod:forward(cinput, {ctarget, cweights})
+   local cgin = cmod:backward(cinput, {ctarget, cweights})
    cutorch.synchronize()
    tm.gpu = a:time().real
 


### PR DESCRIPTION
Hi, 

I am currently working on re-implementing faste-rcnn (http://arxiv.org/abs/1506.01497) and instance-aware semantic segmentation (http://arxiv.org/abs/1512.04412) via torch.

As a part of the work, I made cuda codes for WeightedClassNLLCriterion and WeightedSmoothL1Criterion. The brief explanation of these modules are explained in the updated doc for `criterion`. 

I'm not sure these are properly designed for this repository, but I just want to share them with anyone who might need. 

Best regards, 

Jaehyun 