### PR TITLE
Use 3d thread blocks in SoftMax for inputs with w*h > 2^16-1

### DIFF
--- a/lib/THCUNN/SoftMax.cu
+++ b/lib/THCUNN/SoftMax.cu
@@ -5,11 +5,11 @@
 #define SOFTMAX_THREADS 128
 
 __global__ void cunn_SoftMax_updateOutput_kernel(
-  float *output, float *input, int nframe, int dim, int stride)
+  float *output, float *input, int nframe, int dim, int stride0, int stride1)
 {
   __shared__ float buffer[SOFTMAX_THREADS+1];
-  float *input_k = input + blockIdx.x*dim*stride + blockIdx.y;
-  float *output_k = output + blockIdx.x*dim*stride + blockIdx.y;
+  float *input_k  = input  + blockIdx.x*dim*stride0 + blockIdx.y*stride1 + blockIdx.z;
+  float *output_k = output + blockIdx.x*dim*stride0 + blockIdx.y*stride1 + blockIdx.z;
 
   int i_start = threadIdx.x;
   int i_end = dim;
@@ -19,8 +19,8 @@ __global__ void cunn_SoftMax_updateOutput_kernel(
   buffer[threadIdx.x] = -FLT_MAX;
   for (int i=i_start; i<i_end; i+=i_step)
   {
-    float z = input_k[i*stride];
-    if(buffer[threadIdx.x] < z)
+    float z = input_k[i*stride0];
+    if (buffer[threadIdx.x] < z)
       buffer[threadIdx.x] = z;
   }
 
@@ -32,7 +32,7 @@ __global__ void cunn_SoftMax_updateOutput_kernel(
     float max_k = -FLT_MAX;
     for (int i=0; i<blockDim.x; i++)
     {
-      if(max_k < buffer[i])
+      if (max_k < buffer[i])
         max_k = buffer[i];
     }
     buffer[SOFTMAX_THREADS] = max_k;
@@ -44,9 +44,9 @@ __global__ void cunn_SoftMax_updateOutput_kernel(
   float max_k = buffer[SOFTMAX_THREADS];
   buffer[threadIdx.x] = 0;
   for (int i=i_start; i<i_end; i+=i_step) {
-    float z = __expf(input_k[i*stride]-max_k);
+    float z = __expf(input_k[i*stride0]-max_k);
     buffer[threadIdx.x] += z;
-    output_k[i*stride] = z;
+    output_k[i*stride0] = z;
   }
 
   __syncthreads();
@@ -65,16 +65,16 @@ __global__ void cunn_SoftMax_updateOutput_kernel(
   // softmax
   float sum_k = buffer[SOFTMAX_THREADS];
   for (int i=i_start; i<i_end; i+=i_step)
-    output_k[i*stride] = output_k[i*stride] / sum_k;
+    output_k[i*stride0] = output_k[i*stride0] / sum_k;
 }
 
 __global__ void cunn_SoftMax_updateGradInput_kernel(
-  float *gradInput, float *output, float *gradOutput, int nframe, int dim, int stride)
+  float *gradInput, float *output, float *gradOutput, int nframe, int dim, int stride0, int stride1)
 {
   __shared__ float buffer[SOFTMAX_THREADS];
-  float *gradInput_k = gradInput + blockIdx.x*dim*stride + blockIdx.y;
-  float *output_k = output + blockIdx.x*dim*stride + blockIdx.y;
-  float *gradOutput_k = gradOutput + blockIdx.x*dim*stride + blockIdx.y;
+  float *gradInput_k  = gradInput  + blockIdx.x*dim*stride0 + blockIdx.y * stride1 + blockIdx.z;
+  float *output_k     = output     + blockIdx.x*dim*stride0 + blockIdx.y * stride1 + blockIdx.z;
+  float *gradOutput_k = gradOutput + blockIdx.x*dim*stride0 + blockIdx.y * stride1 + blockIdx.z;
 
   int i_start = threadIdx.x;
   int i_end = dim;
@@ -83,7 +83,7 @@ __global__ void cunn_SoftMax_updateGradInput_kernel(
   // sum?
   buffer[threadIdx.x] = 0;
   for (int i=i_start; i<i_end; i+=i_step)
-    buffer[threadIdx.x] += gradOutput_k[i*stride] * output_k[i*stride];
+    buffer[threadIdx.x] += gradOutput_k[i*stride0] * output_k[i*stride0];
 
   __syncthreads();
 
@@ -100,7 +100,7 @@ __global__ void cunn_SoftMax_updateGradInput_kernel(
 
   float sum_k = buffer[0];
   for (int i=i_start; i<i_end; i+=i_step)
-    gradInput_k[i*stride] = output_k[i*stride] * (gradOutput_k[i*stride] - sum_k);
+    gradInput_k[i*stride0] = output_k[i*stride0] * (gradOutput_k[i*stride0] - sum_k);
 }
 
 void THNN_CudaSoftMax_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *output)
@@ -109,43 +109,57 @@ void THNN_CudaSoftMax_updateOutput(THCState *state, THCudaTensor *input, THCudaT
 
   input = THCudaTensor_newContiguous(state, input);
   THCudaTensor_resizeAs(state, output, input);
-  long batchSize, dim, stride;
+  long batchSize, dim, stride0, stride1 = 1;
+  long blocksY = 1, blocksZ = 1;
 
   if (input->nDimension == 1)
   {
     batchSize = 1;
     dim = input->size[0];
-    stride = 1;
+    stride0 = 1;
   }
   else if (input->nDimension == 2)
   {
     batchSize = input->size[0];
     dim = input->size[1];
-    stride = 1;
+    stride0 = 1;
   }
   else if (input->nDimension == 3)
   {
     batchSize = 1;
     dim = input->size[0];
-    stride = input->size[1] * input->size[2];
+    blocksY = input->size[1];
+    blocksZ = input->size[2];
+    stride0 = blocksY * blocksZ;
+    stride1 = blocksZ;
   }
   else if (input->nDimension == 4)
   {
     batchSize = input->size[0];
     dim = input->size[1];
-    stride = input->size[2] * input->size[3];
+    blocksY = input->size[2];
+    blocksZ = input->size[3];
+    stride0 = blocksY * blocksZ;
+    stride1 = blocksZ;
   }
   else
   {
     THError("1D, 2D, 3D or 4D tensor expected");
   }
 
-  dim3 blocks(batchSize, stride);
+  // when possible use only 2d grid of thread blocks to stay compatible with compute capability 2.X devices.
+  if (blocksY * blocksZ < 65536)
+  {
+    blocksY *= blocksZ;
+    blocksZ = 1;
+  }
+
+  dim3 blocks(batchSize, blocksY, blocksZ);
   dim3 threads(SOFTMAX_THREADS);
-  cunn_SoftMax_updateOutput_kernel<<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
+  cunn_SoftMax_updateOutput_kernel<<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
     THCudaTensor_data(state, output),
     THCudaTensor_data(state, input),
-    batchSize, dim, stride
+    batchSize, dim, stride0, stride1
   );
 
   cudaError errcode = cudaGetLastError();
@@ -163,44 +177,58 @@ void THNN_CudaSoftMax_updateGradInput(THCState *state, THCudaTensor *input, THCu
   gradOutput = THCudaTensor_newContiguous(state, gradOutput);
 
   THCudaTensor_resizeAs(state, gradInput, output);
-  long batchSize, dim, stride;
+  long batchSize, dim, stride0, stride1 = 1;
+  long blocksY = 1, blocksZ = 1;
 
   if (gradInput->nDimension == 1)
   {
     batchSize = 1;
     dim = gradInput->size[0];
-    stride = 1;
+    stride0 = 1;
   }
   else if (gradInput->nDimension == 2)
   {
     batchSize = gradInput->size[0];
     dim = gradInput->size[1];
-    stride = 1;
+    stride0 = 1;
   }
   else if (gradInput->nDimension == 3)
   {
     batchSize = 1;
     dim = gradInput->size[0];
-    stride = gradInput->size[1] * gradInput->size[2];
+    blocksY = gradInput->size[1];
+    blocksZ = gradInput->size[2];
+    stride0 = blocksY * blocksZ;
+    stride1 = blocksZ;
   }
   else if (gradInput->nDimension == 4)
   {
     batchSize = gradInput->size[0];
     dim = gradInput->size[1];
-    stride = gradInput->size[2] * gradInput->size[3];
+    blocksY = gradInput->size[2];
+    blocksZ = gradInput->size[3];
+    stride0 = blocksY * blocksZ;
+    stride1 = blocksZ;
   }
   else
   {
     THError("1D, 2D, 3D or 4D tensor expected");
   }
 
-  dim3 blocks(batchSize, stride);
+  // when possible use only 2d grid of thread blocks to stay compatible with compute capability 2.X devices.
+  if (blocksY * blocksZ < 65536)
+  {
+    blocksY *= blocksZ;
+    blocksZ = 1;
+  }
+
+  dim3 blocks(batchSize, blocksY, blocksZ);
   dim3 threads(SOFTMAX_THREADS);
-  cunn_SoftMax_updateGradInput_kernel<<<blocks,threads, 0, THCState_getCurrentStream(state)>>>(
+  cunn_SoftMax_updateGradInput_kernel<<<blocks, threads, 0, THCState_getCurrentStream(state)>>>(
     THCudaTensor_data(state, gradInput),
     THCudaTensor_data(state, output),
     THCudaTensor_data(state, gradOutput),
-    batchSize, dim, stride
+    batchSize, dim, stride0, stride1
   );
 
   cudaError errcode = cudaGetLastError();


### PR DESCRIPTION
Fix for https://github.com/torch/cunn/issues/150.
In oder to stay compatible with compute capability 2.X devices a 3D grid is only used for inputs with width*height > 65335.

Todo:
- Analyse performance impact for 3d thread block grid

Would be great if somebody could review/test.

Beside running cunn.test() I compared with the CPU results:

```
require 'cunn'
-- cpu:
s1 = nn.SpatialSoftMax()
x1 = torch.rand(2,16,300,300)

-- gpu:
s2 = nn.SpatialSoftMax()
s2:cuda()
x2 = x1:cuda()

y1 = s1:forward(x1)
y2 = s2:forward(x2)

d = (y1-y2:double()):abs()
err_max = d:max()
err_avg = d:sum()/d:nElement()
print(string.format('err_max: %e, err_avg: %e', err_max, err_avg)) 
```