### PR TITLE
NLL Criteria: weight bound checking

### DIFF
--- a/lib/THCUNN/ClassNLLCriterion.cu
+++ b/lib/THCUNN/ClassNLLCriterion.cu
@@ -128,6 +128,9 @@ void THNN_CudaClassNLLCriterion_updateOutput(THCState *state, THCudaTensor *inpu
   if (THCudaTensor_nDimension(state, input) > 2) {
     THArgCheck(0, 2, "vector or matrix expected");
   }
+  if (weights && THCudaTensor_nElement(state, weights) != n_classes) {
+    THError("weight tensor should be defined either for all or no classes");
+  }
 
   input = THCudaTensor_newContiguous(state, input);
   weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;
@@ -197,6 +200,9 @@ void THNN_CudaClassNLLCriterion_updateGradInput(THCState *state, THCudaTensor *i
 
   if (THCudaTensor_nDimension(state, input) > 2) {
     THArgCheck(0, 2, "vector or matrix expected");
+  }
+  if (weights && THCudaTensor_nElement(state, weights) != n_classes) {
+    THError("weight tensor should be defined either for all or no classes");
   }
 
   weights = weights ? THCudaTensor_newContiguous(state, weights) : NULL;

--- a/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -96,6 +96,9 @@ void THNN_CudaSpatialClassNLLCriterion_updateOutput(
                "only batches of spatial targets supported (3D tensors)");
   THArgCheck(THCudaTensor_nDimension(state, input) == 4, 2,
                "only batches of spatial inputs supported (4D tensors)");
+  if (weights && THCudaTensor_nElement(state, weights) != THCudaTensor_size(state, input, 1)) {
+    THError("weight tensor should be defined either for all or no classes");
+  }
 
   if (weights)
     THCUNN_assertSameGPU(state, 5, input, target, weights, output, total_weight);
@@ -157,6 +160,9 @@ void THNN_CudaSpatialClassNLLCriterion_updateGradInput(
                "only batches of spatial inputs supported (4D tensors)");
   THArgCheck(THCudaTensor_isContiguous(state, gradInput), 4,
                "gradInput must be contiguous");
+  if (weights && THCudaTensor_nElement(state, weights) != THCudaTensor_size(state, input, 1)) {
+    THError("weight tensor should be defined either for all or no classes");
+  }
 
   if (weights)
     THCUNN_assertSameGPU(state, 5, weights, input, target, gradInput, total_weight);


### PR DESCRIPTION
Checks that there are as many weights as classes (before, undefined values could be used).