### PR TITLE
gemm -> Sgemm

### DIFF
--- a/lib/THCUNN/SpatialConvolutionMM.cu
+++ b/lib/THCUNN/SpatialConvolutionMM.cu
@@ -75,7 +75,7 @@ void THNN_CudaSpatialConvolutionMM_updateOutput(THCState *state, THCudaTensor *i
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     if (bias) {
-      THCudaBlas_gemm(
+      THCudaBlas_Sgemm(
           state,
           't', 'n',
           n_, m_, k_,
@@ -104,7 +104,7 @@ void THNN_CudaSpatialConvolutionMM_updateOutput(THCState *state, THCudaTensor *i
     long k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 'n',
         n, m, k,
@@ -179,7 +179,7 @@ void THNN_CudaSpatialConvolutionMM_updateGradInput(THCState *state, THCudaTensor
     long k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 't',
         n, m, k,
@@ -278,7 +278,7 @@ void THNN_CudaSpatialConvolutionMM_accGradParameters(THCState *state, THCudaTens
     long k = columns->size[1];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         't', 'n',
         n, m, k,
@@ -297,7 +297,7 @@ void THNN_CudaSpatialConvolutionMM_accGradParameters(THCState *state, THCudaTens
 
     // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
-      THCudaBlas_gemv(
+      THCudaBlas_Sgemv(
           state,
           't',
           k_, m_,

--- a/lib/THCUNN/SpatialDilatedConvolution.cu
+++ b/lib/THCUNN/SpatialDilatedConvolution.cu
@@ -79,7 +79,7 @@ void THNN_CudaSpatialDilatedConvolution_updateOutput(THCState *state,
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     if (bias) {
-      THCudaBlas_gemm(
+      THCudaBlas_Sgemm(
           state,
           't', 'n',
           n_, m_, k_,
@@ -109,7 +109,7 @@ void THNN_CudaSpatialDilatedConvolution_updateOutput(THCState *state,
     long k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 'n',
         n, m, k,
@@ -189,7 +189,7 @@ void THNN_CudaSpatialDilatedConvolution_updateGradInput(THCState *state,
     long k = nOutputPlane;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 't',
         n, m, k,
@@ -295,7 +295,7 @@ void THNN_CudaSpatialDilatedConvolution_accGradParameters(THCState *state,
     long k = columns->size[1];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         't', 'n',
         n, m, k,
@@ -314,7 +314,7 @@ void THNN_CudaSpatialDilatedConvolution_accGradParameters(THCState *state,
 
     // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
-      THCudaBlas_gemv(
+      THCudaBlas_Sgemv(
           state,
           't',
           k_, m_,

--- a/lib/THCUNN/SpatialFullConvolution.cu
+++ b/lib/THCUNN/SpatialFullConvolution.cu
@@ -74,7 +74,7 @@ void THNN_CudaSpatialFullConvolution_updateOutput(
     long k = weight->size[0];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 't',
         n, m, k,
@@ -102,7 +102,7 @@ void THNN_CudaSpatialFullConvolution_updateOutput(
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
     if (bias) {
-      THCudaBlas_gemm(
+      THCudaBlas_Sgemm(
           state,
           't', 'n',
           n_, m_, k_,
@@ -194,7 +194,7 @@ void THNN_CudaSpatialFullConvolution_updateGradInput(
     long k = weight->size[1] * weight->size[2] * weight->size[3];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 'n',
         n, m, k,
@@ -293,7 +293,7 @@ void THNN_CudaSpatialFullConvolution_accGradParameters(
     long k = columns->size[1];   // inputHeight * inputWidth
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         't', 'n',
         n, m, k,
@@ -312,7 +312,7 @@ void THNN_CudaSpatialFullConvolution_accGradParameters(
 
     // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
     if (gradBias) {
-      THCudaBlas_gemv(
+      THCudaBlas_Sgemv(
           state,
           't',
           k_, m_,

--- a/lib/THCUNN/VolumetricConvolution.cu
+++ b/lib/THCUNN/VolumetricConvolution.cu
@@ -233,7 +233,7 @@ void THNN_CudaVolumetricConvolution_updateOutput(
     long k_ = 1;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
       state,
       't', 'n',
       n_, m_, k_,
@@ -259,7 +259,7 @@ void THNN_CudaVolumetricConvolution_updateOutput(
     long k = weight->size[1]*weight->size[2]*weight->size[3]*weight->size[4];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
       state,
       'n', 'n',
       n, m, k,
@@ -355,7 +355,7 @@ void THNN_CudaVolumetricConvolution_updateGradInput(
     long k = weight->size[0];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
       state,
       'n', 't',
       n, m, k,
@@ -476,7 +476,7 @@ void THNN_CudaVolumetricConvolution_accGradParameters(
     long k = columns->size[1];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
       state,
       't', 'n',
       n, m, k,
@@ -494,7 +494,7 @@ void THNN_CudaVolumetricConvolution_accGradParameters(
     long k_ = outputDepth * outputHeight * outputWidth;
 
     // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
-    THCudaBlas_gemv(
+    THCudaBlas_Sgemv(
       state,
       't',
       k_, m_,

--- a/lib/THCUNN/VolumetricFullConvolution.cu
+++ b/lib/THCUNN/VolumetricFullConvolution.cu
@@ -81,7 +81,7 @@ void THNN_CudaVolumetricFullConvolution_updateOutput(
     long k = weight->size[0];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 't',
         n, m, k,
@@ -108,7 +108,7 @@ void THNN_CudaVolumetricFullConvolution_updateOutput(
     long k_ = 1;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         't', 'n',
         n_, m_, k_,
@@ -206,7 +206,7 @@ void THNN_CudaVolumetricFullConvolution_updateGradInput(
     long k = weight->size[1] * weight->size[2] * weight->size[3] * weight->size[4];
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         'n', 'n',
         n, m, k,
@@ -311,7 +311,7 @@ void THNN_CudaVolumetricFullConvolution_accGradParameters(
     long k = columns->size[1];   // inputHeight * inputWidth
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    THCudaBlas_gemm(
+    THCudaBlas_Sgemm(
         state,
         't', 'n',
         n, m, k,
@@ -329,7 +329,7 @@ void THNN_CudaVolumetricFullConvolution_accGradParameters(
     long k_ = outputDepth * outputHeight * outputWidth;
 
     // Do GEMV (note: this is a bit confusing because gemv assumes column-major matrices)
-    THCudaBlas_gemv(
+    THCudaBlas_Sgemv(
         state,
         't',
         k_, m_,


### PR DESCRIPTION
cutorch introduced the change gemm -> Sgemm and gemv -> Sgemv in master.
Fixing it in cunn.
If one wants to use the old cutorch / cunn, 1.0-0 is a stable previous version without breaking API changes.

```bash
luarocks remove --force cutorch
luarocks remove --force cunn
luarocks install cunn 1.0-0
```