### PR TITLE
inplace is reversed in HardTanh:backward.

### DIFF
--- a/lib/THCUNN/HardTanh.cu
+++ b/lib/THCUNN/HardTanh.cu
@@ -90,14 +90,14 @@ void THNN_CudaHardTanh_updateGradInput(
 
   if (inplace)
   {
-    THCudaTensor_resizeAs(state, gradInput, input);
-    THC_pointwiseApply3(state, gradInput, input, gradOutput,
+    THCudaTensor_set(state, gradInput, gradOutput);
+    THC_pointwiseApply2(state, gradInput, input,
                                  hardtanhupdateGradInput_functor(min_val, max_val));
   }
   else
   {
-    THCudaTensor_set(state, gradInput, gradOutput);
-    THC_pointwiseApply2(state, gradInput, input,
+    THCudaTensor_resizeAs(state, gradInput, input);
+    THC_pointwiseApply3(state, gradInput, input, gradOutput,
                                  hardtanhupdateGradInput_functor(min_val, max_val));
   }
 }


### PR DESCRIPTION
Fixes torch7 issue #734, "Inconsistent behavior of nn.Clamp in CPU and GPU modes".
Adds a simple test that gradOutput equals gradInput after backward when inplace is set.
It is possible to construct a test with inplace HardTanh where forward+backward yields
different results for nn vs cunn, but this appears to be due to the inclusive vs
exclusive bounds used for inplace vs non-inplace, respectively, so a more direct test
is preferred.