### PR TITLE
Allow empty parameter in type

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -351,6 +351,9 @@ function DataParallelTable:reset(stdv)
 end
 
 function DataParallelTable:type(typeStr)
+   if not typeStr then
+      return self._type
+   end
    assert(typeStr == 'torch.CudaTensor', 'DataParallelTable supports only torch.CudaTensor type')
    for i, m in ipairs(self.modules) do
       m:type(typeStr)


### PR DESCRIPTION
Makes it consistent with usage of :type() for nn.Module (https://github.com/torch/nn/blob/master/Module.lua#L117-L120)

So model:type() can be used to get type of model, even if model has a DPT.