### PR TITLE
BCECriterion THCUNN + Weights

### DIFF
--- a/lib/THCUNN/BCECriterion.cu
+++ b/lib/THCUNN/BCECriterion.cu
@@ -1,40 +1,55 @@
 #include "THCUNN.h"
 #include "common.h"
 
-#include <thrust/fill.h>
 #include <thrust/functional.h>
 #include <thrust/device_ptr.h>
-#include <thrust/reduce.h>
-#include <thrust/inner_product.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/transform.h>
+#include <thrust/transform_reduce.h>
 
 const float eps = 1e-12f;
 
 struct bce_functor
 {
-  __host__ __device__ float operator()(const float& x, const float& y) const
+  template <class Tuple>
+  __host__ __device__
+  float operator()(Tuple x)
   {
-    return - logf(x + eps) * y - logf(1.f - x + eps) * (1.f - y);
+    float o = thrust::get<0>(x);
+    float t = thrust::get<1>(x);
+    float w = thrust::get<2>(x);
+    return - w * (t * logf(o + eps) + (1.f - t) * logf(1.f - o + eps));
   }
 };
 
 void THNN_CudaBCECriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights)
 {
-  THCUNN_assertSameGPU(state, 2, input, target);
+  THCUNN_assertSameGPU(state, 3, input, target, weights);
 
   long size = THCudaTensor_nElement(state, input);
 
   input = THCudaTensor_newContiguous(state, input);
   target = THCudaTensor_newContiguous(state, target);
+  weights = THCudaTensor_newContiguous(state, weights);
 
   thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
   thrust::device_ptr<float> target_data(THCudaTensor_data(state, target));
-  float sum = thrust::inner_product(input_data, input_data+size, target_data, (float) 0, thrust::plus<float>(), bce_functor());
+  thrust::device_ptr<float> weights_data(THCudaTensor_data(state, weights));
+
+  float sum = thrust::transform_reduce(
+    thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data, weights_data)),
+    thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size, weights_data+size)),
+    bce_functor(),
+    (float) 0.f,
+    thrust::plus<float>()
+  );
 
   if (sizeAverage)
     sum /= size;
 
   THCudaTensor_free(state, input);
   THCudaTensor_free(state, target);
+  THCudaTensor_free(state, weights);
 
   THCudaTensor_set1d(state, output, 0, sum);
 }
@@ -48,30 +63,43 @@ struct bce_updateGradInput_functor
     : norm(norm_)
   {}
 
-  __host__ __device__ float operator()(const float& x, const float& y) const
+  template <class Tuple>
+  __host__ __device__
+  float operator()(Tuple x)
   {
-    return - (y - x) / ((1 - x + eps) * (x + eps)) * norm;
+    float o = thrust::get<0>(x);
+    float t = thrust::get<1>(x);
+    float w = thrust::get<2>(x);
+    return - (t - o) / ((1 - o + eps) * (o + eps)) * norm * w;
   }
 };
 
 void THNN_CudaBCECriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights)
 {
-  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
+  THCUNN_assertSameGPU(state, 4, input, target, weights, gradInput);
 
   long size = THCudaTensor_nElement(state, input);
   float norm = (sizeAverage ? 1./size : 1.);
 
   input = THCudaTensor_newContiguous(state, input);
   target = THCudaTensor_newContiguous(state, target);
+  weights = THCudaTensor_newContiguous(state, weights);
 
   THCudaTensor_resizeAs(state, gradInput, input);
 
   thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
   thrust::device_ptr<float> target_data(THCudaTensor_data(state, target));
+  thrust::device_ptr<float> weights_data(THCudaTensor_data(state, weights));
   thrust::device_ptr<float> gradInput_data(THCudaTensor_data(state, gradInput));
 
-  thrust::transform(input_data, input_data+size, target_data, gradInput_data, bce_updateGradInput_functor(norm));
+  thrust::transform(
+    thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data, weights_data)),
+    thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size, weights_data+size)),
+    gradInput_data,
+    bce_updateGradInput_functor(norm)
+  );
 
   THCudaTensor_free(state, input);
   THCudaTensor_free(state, target);
+  THCudaTensor_free(state, weights);
 }

--- a/lib/THCUNN/BCECriterion.cu
+++ b/lib/THCUNN/BCECriterion.cu
@@ -36,11 +36,7 @@ struct bce_functor_weights
 
 void THNN_CudaBCECriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights)
 {
-  if (weights) {
-    THCUNN_assertSameGPU(state, 3, input, target, weights);
-  } else {
-    THCUNN_assertSameGPU(state, 2, input, target);
-  }
+  THCUNN_assertSameGPU(state, 3, input, target, weights);
 
   long size = THCudaTensor_nElement(state, input);
 
@@ -120,11 +116,7 @@ struct bce_updateGradInput_functor_weights
 
 void THNN_CudaBCECriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights)
 {
-  if (weights) {
-    THCUNN_assertSameGPU(state, 4, input, target, gradInput, weights);
-  } else {
-    THCUNN_assertSameGPU(state, 3, input, target, gradInput);
-  }
+  THCUNN_assertSameGPU(state, 4, input, target, gradInput, weights);
 
   long size = THCudaTensor_nElement(state, input);
   float norm = (sizeAverage ? 1./size : 1.);

--- a/lib/THCUNN/BCECriterion.cu
+++ b/lib/THCUNN/BCECriterion.cu
@@ -17,6 +17,18 @@ struct bce_functor
   {
     float o = thrust::get<0>(x);
     float t = thrust::get<1>(x);
+    return - (t * logf(o + eps) + (1.f - t) * logf(1.f - o + eps));
+  }
+};
+
+struct bce_functor_weights
+{
+  template <class Tuple>
+  __host__ __device__
+  float operator()(Tuple x)
+  {
+    float o = thrust::get<0>(x);
+    float t = thrust::get<1>(x);
     float w = thrust::get<2>(x);
     return - w * (t * logf(o + eps) + (1.f - t) * logf(1.f - o + eps));
   }
@@ -24,42 +36,74 @@ struct bce_functor
 
 void THNN_CudaBCECriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights)
 {
-  THCUNN_assertSameGPU(state, 3, input, target, weights);
+  if (weights) {
+    THCUNN_assertSameGPU(state, 3, input, target, weights);
+  } else {
+    THCUNN_assertSameGPU(state, 2, input, target);
+  }
 
   long size = THCudaTensor_nElement(state, input);
 
   input = THCudaTensor_newContiguous(state, input);
   target = THCudaTensor_newContiguous(state, target);
-  weights = THCudaTensor_newContiguous(state, weights);
 
   thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
   thrust::device_ptr<float> target_data(THCudaTensor_data(state, target));
-  thrust::device_ptr<float> weights_data(THCudaTensor_data(state, weights));
 
-  float sum = thrust::transform_reduce(
-    thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data, weights_data)),
-    thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size, weights_data+size)),
-    bce_functor(),
-    (float) 0.f,
-    thrust::plus<float>()
-  );
+  float sum;
+  if (weights) {
+    weights = THCudaTensor_newContiguous(state, weights);
+    thrust::device_ptr<float> weights_data(THCudaTensor_data(state, weights));
+    sum = thrust::transform_reduce(
+      thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data, weights_data)),
+      thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size, weights_data+size)),
+      bce_functor_weights(),
+      (float) 0.f,
+      thrust::plus<float>()
+    );
+    THCudaTensor_free(state, weights);
+  } else {
+    sum = thrust::transform_reduce(
+      thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data)),
+      thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size)),
+      bce_functor(),
+      (float) 0.f,
+      thrust::plus<float>()
+    );
+  }
 
   if (sizeAverage)
     sum /= size;
 
   THCudaTensor_free(state, input);
   THCudaTensor_free(state, target);
-  THCudaTensor_free(state, weights);
 
   THCudaTensor_set1d(state, output, 0, sum);
 }
-
 
 struct bce_updateGradInput_functor
 {
   const float norm;
 
   bce_updateGradInput_functor(float norm_)
+    : norm(norm_)
+  {}
+
+  template <class Tuple>
+  __host__ __device__
+  float operator()(Tuple x)
+  {
+    float o = thrust::get<0>(x);
+    float t = thrust::get<1>(x);
+    return - (t - o) / ((1 - o + eps) * (o + eps)) * norm;
+  }
+};
+
+struct bce_updateGradInput_functor_weights
+{
+  const float norm;
+
+  bce_updateGradInput_functor_weights(float norm_)
     : norm(norm_)
   {}
 
@@ -76,30 +120,43 @@ struct bce_updateGradInput_functor
 
 void THNN_CudaBCECriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights)
 {
-  THCUNN_assertSameGPU(state, 4, input, target, weights, gradInput);
+  if (weights) {
+    THCUNN_assertSameGPU(state, 4, input, target, gradInput, weights);
+  } else {
+    THCUNN_assertSameGPU(state, 3, input, target, gradInput);
+  }
 
   long size = THCudaTensor_nElement(state, input);
   float norm = (sizeAverage ? 1./size : 1.);
 
   input = THCudaTensor_newContiguous(state, input);
   target = THCudaTensor_newContiguous(state, target);
-  weights = THCudaTensor_newContiguous(state, weights);
 
   THCudaTensor_resizeAs(state, gradInput, input);
 
   thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
   thrust::device_ptr<float> target_data(THCudaTensor_data(state, target));
-  thrust::device_ptr<float> weights_data(THCudaTensor_data(state, weights));
   thrust::device_ptr<float> gradInput_data(THCudaTensor_data(state, gradInput));
 
-  thrust::transform(
-    thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data, weights_data)),
-    thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size, weights_data+size)),
-    gradInput_data,
-    bce_updateGradInput_functor(norm)
-  );
+  if (weights) {
+    weights = THCudaTensor_newContiguous(state, weights);
+    thrust::device_ptr<float> weights_data(THCudaTensor_data(state, weights));
+    thrust::transform(
+      thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data, weights_data)),
+      thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size, weights_data+size)),
+      gradInput_data,
+      bce_updateGradInput_functor_weights(norm)
+    );
+    THCudaTensor_free(state, weights);
+  } else {
+    thrust::transform(
+      thrust::make_zip_iterator(thrust::make_tuple(input_data, target_data)),
+      thrust::make_zip_iterator(thrust::make_tuple(input_data+size, target_data+size)),
+      gradInput_data,
+      bce_updateGradInput_functor(norm)
+    );
+  }
 
   THCudaTensor_free(state, input);
   THCudaTensor_free(state, target);
-  THCudaTensor_free(state, weights);
 }

--- a/lib/THCUNN/BCECriterion.cu
+++ b/lib/THCUNN/BCECriterion.cu
@@ -1,0 +1,77 @@
+#include "THCUNN.h"
+#include "common.h"
+
+#include <thrust/fill.h>
+#include <thrust/functional.h>
+#include <thrust/device_ptr.h>
+#include <thrust/reduce.h>
+#include <thrust/inner_product.h>
+
+const float eps = 1e-12f;
+
+struct bce_functor
+{
+  __host__ __device__ float operator()(const float& x, const float& y) const
+  {
+    return - logf(x + eps) * y - logf(1.f - x + eps) * (1.f - y);
+  }
+};
+
+void THNN_CudaBCECriterion_updateOutput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *output, bool sizeAverage, THCudaTensor *weights)
+{
+  THCUNN_assertSameGPU(state, 2, input, target);
+
+  long size = THCudaTensor_nElement(state, input);
+
+  input = THCudaTensor_newContiguous(state, input);
+  target = THCudaTensor_newContiguous(state, target);
+
+  thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
+  thrust::device_ptr<float> target_data(THCudaTensor_data(state, target));
+  float sum = thrust::inner_product(input_data, input_data+size, target_data, (float) 0, thrust::plus<float>(), bce_functor());
+
+  if (sizeAverage)
+    sum /= size;
+
+  THCudaTensor_free(state, input);
+  THCudaTensor_free(state, target);
+
+  THCudaTensor_set1d(state, output, 0, sum);
+}
+
+
+struct bce_updateGradInput_functor
+{
+  const float norm;
+
+  bce_updateGradInput_functor(float norm_)
+    : norm(norm_)
+  {}
+
+  __host__ __device__ float operator()(const float& x, const float& y) const
+  {
+    return - (y - x) / ((1 - x + eps) * (x + eps)) * norm;
+  }
+};
+
+void THNN_CudaBCECriterion_updateGradInput(THCState *state, THCudaTensor *input, THCudaTensor *target, THCudaTensor *gradInput, bool sizeAverage, THCudaTensor *weights)
+{
+  THCUNN_assertSameGPU(state, 3, input, target, gradInput);
+
+  long size = THCudaTensor_nElement(state, input);
+  float norm = (sizeAverage ? 1./size : 1.);
+
+  input = THCudaTensor_newContiguous(state, input);
+  target = THCudaTensor_newContiguous(state, target);
+
+  THCudaTensor_resizeAs(state, gradInput, input);
+
+  thrust::device_ptr<float> input_data(THCudaTensor_data(state, input));
+  thrust::device_ptr<float> target_data(THCudaTensor_data(state, target));
+  thrust::device_ptr<float> gradInput_data(THCudaTensor_data(state, gradInput));
+
+  thrust::transform(input_data, input_data+size, target_data, gradInput_data, bce_updateGradInput_functor(norm));
+
+  THCudaTensor_free(state, input);
+  THCudaTensor_free(state, target);
+}

--- a/lib/THCUNN/THCUNN.h
+++ b/lib/THCUNN/THCUNN.h
@@ -30,6 +30,21 @@ TH_API void THNN_CudaAbsCriterion_updateGradInput(
           THCudaTensor *gradInput,
           bool sizeAverage);
 
+TH_API void THNN_CudaBCECriterion_updateOutput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *output,
+          bool sizeAverage,
+          THCudaTensor *weights);
+TH_API void THNN_CudaBCECriterion_updateGradInput(
+          THCState *state,
+          THCudaTensor *input,
+          THCudaTensor *target,
+          THCudaTensor *gradInput,
+          bool sizeAverage,
+          THCudaTensor *weights);
+
 TH_API void THNN_CudaClassNLLCriterion_updateOutput(
           THCState *state,
           THCudaTensor *input,

--- a/test.lua
+++ b/test.lua
@@ -3053,7 +3053,7 @@ end
 
 -- Criterion tests
 
-function BCECriterion_forward_truth(buffer, input, target, weights, sizeAverage)
+local function BCECriterion_forward_truth(buffer, input, target, weights, sizeAverage)
 
   local eps = 1e-12
   local output

--- a/test.lua
+++ b/test.lua
@@ -3052,6 +3052,37 @@ end
 
 
 -- Criterion tests
+function cunntest.BCECriterion_forward()
+  local size = math.random(1,100)
+  local input = torch.Tensor(size):uniform()
+  local target = torch.Tensor(size):uniform():gt(0.5):type(torch.type(input))
+
+  local tm = {}
+  local title = string.format('BCECriterion.forward, Size: %d', size)
+  times[title] = tm
+
+  local crit = nn.BCECriterion()
+  local groundtruth= crit:forward(input, target)
+  local a = torch.Timer()
+  for i = 1,nloop do
+     groundtruth = crit:forward(input, target)
+  end
+  tm.cpu = a:time().real
+
+  input = input:cuda()
+  target = target:cuda()
+  local g_crit = nn.BCECriterion():cuda()
+  local rescuda = g_crit:forward(input, target)
+  a:reset()
+  for i = 1,nloop do
+     rescuda = g_crit:forward(input, target)
+  end
+  cutorch.synchronize()
+  tm.gpu = a:time().real
+  local errorVal = rescuda - groundtruth
+  mytester:assertlt(errorVal, precision_forward, 'error on state (forward) ')
+end
+
 
 function cunntest.MarginCriterion_forward()
   local size = math.random(1,100)
@@ -3230,6 +3261,42 @@ function cunntest.MarginCriterion_backward()
    input = input:cuda()
    target = target:cuda()
    local g_crit = nn.MarginCriterion():cuda()
+   g_crit:forward(input, target)
+   local rescuda = g_crit:backward(input, target)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = g_crit:backward(input, target)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
+function cunntest.BCECriterion_backward()
+   local size = math.random(1,100)
+
+   local tm = {}
+   local title = string.format('BCECriterion.backward, Size %d', size)
+   times[title] = tm
+
+   local input = torch.Tensor(size):uniform()
+   local target = torch.Tensor(size):uniform():gt(0.5):type(torch.type(input))
+
+   local crit = nn.BCECriterion()
+   crit:forward(input, target)
+   local groundgrad = crit:backward(input, target)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundgrad = crit:backward(input, target)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   target = target:cuda()
+   local g_crit = nn.BCECriterion():cuda()
    g_crit:forward(input, target)
    local rescuda = g_crit:backward(input, target)
    a:reset()


### PR DESCRIPTION
Adds weights support to BCECriterion THCUNN implementation.

Rather than writing a special kernel, I followed [this thrust example](https://github.com/thrust/thrust/blob/master/examples/arbitrary_transformation.cu) to perform a transformation of more than two inputs, replacing `thrust::inner_product` with `thrust::transform_reduce`.

I added two new tests so BCECriterion is tested both with and without weights like in torch/nn.