### PR TITLE
Fix issue with flatten parameters in DataParallelTable

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -113,9 +113,10 @@ function DataParallelTable:flattenParameters()
       end
       if flattened then
          local pp = torch.CudaTensor(p[1]:storage(), p[1]:storageOffset(),
-                    p[#p]:storageOffset()+p[#p]:numel()-1)
+                    p[#p]:storageOffset()+p[#p]:numel()-p[1]:storageOffset())
          local dpp = torch.CudaTensor(dp[1]:storage(), dp[1]:storageOffset(),
-                     dp[#dp]:storageOffset()+dp[#dp]:numel()-1)
+                     dp[#dp]:storageOffset()+dp[#dp]:numel()
+                      - dp[1]:storageOffset())
          return {pp, dpp}
       else
          return { module:getParameters() }


### PR DESCRIPTION
Currently, if only a part of a network is wrapped with DataParallelTable and flattenParameters is enabled, then the flat tensor created is larger than it needs to be due to an issue with offsets. This ends up copying a lot more data during every call to syncParameters.