### PR TITLE
SpatialLogSoftMax

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -426,6 +426,147 @@ function cunntest.LogSoftMax_backward_batch()
    mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
 end
 
+function cunntest.SpatialLogSoftMax_forward()
+   local size = math.random(1,256)
+   local ini = math.random(8,32)
+   local inj = math.random(8,32)
+
+   local tm = {}
+   local title = string.format('SpatialLogSoftMax forward %d x %d x %d', size, inj, ini)
+   times[title] = tm
+
+   local input = torch.randn(size, inj, ini)
+   local sconv = nn.SpatialLogSoftMax()
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = nn.SpatialLogSoftMax():cuda()
+   local rescuda = gconv:forward(input)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward*25, 'error on state (forward) ')
+end
+
+function cunntest.SpatialLogSoftMax_backward()
+   local size = math.random(1,256)
+   local ini = math.random(8,32)
+   local inj = math.random(8,32)
+
+   local tm = {}
+   local title = string.format('SpatialLogSoftMax.backward %d x %d x %d', size, inj, ini)
+   times[title] = tm
+
+   local input = torch.randn(size, inj, ini)
+   local gradOutput = torch.randn(size, inj, ini)
+   local sconv = nn.SpatialLogSoftMax()
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundgrad = sconv:backward(input, gradOutput)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:backward(input, gradOutput)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
+function cunntest.SpatialLogSoftMax_forward_batch()
+   local size = math.random(1,256)
+   local bs = math.random(8,32)
+   local ini = math.random(8,32)
+   local inj = math.random(8,32)
+
+   local tm = {}
+   local title = string.format('SpatialLogSoftMax forward batch %d x %d x %d x %d', bs, size, inj, ini)
+   times[title] = tm
+
+   local input = torch.randn(bs, size, inj, ini)
+   local sconv = nn.SpatialLogSoftMax()
+   local groundtruth = sconv:forward(input)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundtruth = sconv:forward(input)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   local gconv = nn.SpatialLogSoftMax():cuda()
+   local rescuda = gconv:forward(input)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:forward(input)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundtruth
+   mytester:assertlt(error:abs():max(), precision_forward*25, 'error on state (forward) ')
+end
+
+function cunntest.SpatialLogSoftMax_backward_batch()
+   local size = math.random(1,256)
+   local bs = math.random(8,32)
+   local ini = math.random(8,32)
+   local inj = math.random(8,32)
+
+   local tm = {}
+   local title = string.format('SpatialLogSoftMax.backward batch %d x %d x %d x %d', bs, size, inj, ini)
+   times[title] = tm
+
+   local input = torch.randn(bs, size, inj, ini)
+   local gradOutput = torch.randn(bs, size, inj, ini)
+   local sconv = nn.SpatialLogSoftMax()
+   sconv:forward(input)
+   local groundgrad = sconv:backward(input, gradOutput)
+   local a = torch.Timer()
+   for i = 1,nloop do
+      groundgrad = sconv:backward(input, gradOutput)
+   end
+   tm.cpu = a:time().real
+
+   input = input:cuda()
+   gradOutput = gradOutput:cuda()
+   local gconv = sconv:clone():cuda()
+   gconv:forward(input)
+   local rescuda = gconv:backward(input, gradOutput)
+   a:reset()
+   for i = 1,nloop do
+      rescuda = gconv:backward(input, gradOutput)
+   end
+   cutorch.synchronize()
+   tm.gpu = a:time().real
+
+   local error = rescuda:float() - groundgrad
+
+   mytester:assertlt(error:abs():max(), precision_backward, 'error on state (backward) ')
+end
+
+
 function cunntest.Euclidean_forward_batch()
    local bs = math.random(8,32)
    local nin = math.random(1,100)


### PR DESCRIPTION
I updated LogSoftMax to support spatial data with a kernel that accesses the input data in "cuda" format, B x H x W x P, where B is batch size and P is number of classes, for better cache performance. The original commit from @fmassa is included in this PR.