### PR TITLE
test on inputGpu emptiness symmetric in backward and forward

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -231,8 +231,8 @@ function DataParallelTable:__backward(method, input, gradOutput, scale)
       self:_distribute(self.gradOutputGpu, gradOutput)
 
       self.gradInputGpu = self.impl:exec(function(m, i)
-         if torch.isTensor(inputGpu[i]) and inputGpu[i]:numel() == 0 then
-            return torch.CudaTensor()
+         if not _hasData(inputGpu[i]) then
+            return inputGpu[i]
          else
             return m[method](m, inputGpu[i], gradOutputGpu[i], scale)
          end
@@ -246,8 +246,8 @@ function DataParallelTable:__backward(method, input, gradOutput, scale)
 
    if method == 'accGradParameters' then
       self.impl:exec(function(m, i)
-         if torch.isTensor(inputGpu[i]) and inputGpu[i]:numel() == 0 then
-            return torch.CudaTensor()
+         if not _hasData(inputGpu[i]) then
+            return inputGpu[i]
          else
             return m:accGradParameters(inputGpu[i], gradOutputGpu[i], scale)
          end


### PR DESCRIPTION
I had a problem in `updateGradInput` method for small batches for which one of the gpu assignment was empty. 
In `updateOutput` method, emptiness test is done using `_hasData` which includes empty tensor testing but also **empty table testing** (my net is taking table input).

The patch just does the same for `__backward` - let me know if you have any question.
