### PR TITLE
Protect half operations with CUDA_HALF_TENSOR with generic modules.

### DIFF
--- a/lib/THCUNN/RReLU.cu
+++ b/lib/THCUNN/RReLU.cu
@@ -13,10 +13,12 @@
 template<typename T>
 inline T __device__ curand_uniform_type(curandStateMtgp32 *state);
 
+#ifdef CUDA_HALF_TENSOR
 template <>
 inline half __device__ curand_uniform_type<half>(curandStateMtgp32 *state) {
   return ScalarConvert<float, half>::to(curand_uniform(state));
 }
+#endif
 
 template <>
 inline float __device__ curand_uniform_type<float>(curandStateMtgp32 *state) {

--- a/lib/THCUNN/SharedMem.cuh
+++ b/lib/THCUNN/SharedMem.cuh
@@ -13,6 +13,7 @@ struct SharedMem {
   }
 };
 
+#ifdef CUDA_HALF_TENSOR
 template <>
 struct SharedMem<half>
 {
@@ -21,6 +22,7 @@ struct SharedMem<half>
     return s_half;
   }
 };
+#endif
 
 template <>
 struct SharedMem<float>

--- a/lib/THCUNN/SparseLinear.cu
+++ b/lib/THCUNN/SparseLinear.cu
@@ -16,6 +16,7 @@ static void init_cusparse() {
   }
 }
 
+#ifdef CUDA_HALF_TENSOR
 void THNN_CudaHalfSparseLinear_updateOutput(
           THCState *state,
           THCudaHalfTensor *input,
@@ -78,6 +79,7 @@ void THNN_CudaHalfSparseLinear_updateParameters(
           double learningRate) {
   THError("THCudaHalfTensor not supported with SparseLinear");
 }
+#endif
 
 #include "generic/SparseLinear.cu"
 #include "THCGenerateFloatType.h"

--- a/lib/THCUNN/THCHalfAutoNumerics.cuh
+++ b/lib/THCUNN/THCHalfAutoNumerics.cuh
@@ -7,10 +7,9 @@
 // Half numerics functions defined as free functions, so cunn code can be
 //written generically, i.e. without excessive calling of THCNumerics<half> functions.
 
-#ifdef CUDA_HALF_TENSOR
-
 // these functions should move to THCNumerics
 
+#ifdef CUDA_HALF_TENSOR
 inline __host__ __device__ half fmaxType(half x, half y) {
   return THCNumerics<half>::ge(x, y) ? x : y;
 }
@@ -18,6 +17,7 @@ inline __host__ __device__ half fmaxType(half x, half y) {
 inline __host__ __device__ float fmaxType(float x, half y) {
   return fmaxf(x, ScalarConvert<half, float>::to(y));
 }
+#endif
 
 inline __host__ __device__ float fmaxType(float x, float y) {
   return fmaxf(x, y);
@@ -26,6 +26,8 @@ inline __host__ __device__ float fmaxType(float x, float y) {
 inline __host__ __device__ double fmaxType(double x, double y) {
   return fmax(x, y);
 }
+
+#ifdef CUDA_HALF_TENSOR
 
 inline __host__ __device__ half mul(half a, half b) {
   #ifdef __CUDA_ARCH__


### PR DESCRIPTION
This should address https://github.com/torch/torch7/issues/832.

I tested compilation with CUDA 7.0; it fails without and passes with this PR.