### PR TITLE
Improving error messages in nn.

### DIFF
--- a/lib/THCUNN/SpatialReflectionPadding.cu
+++ b/lib/THCUNN/SpatialReflectionPadding.cu
@@ -1,5 +1,5 @@
 #include "THCUNN.h"
-
+#include "common.h"
 #include "THCDeviceTensor.cuh"
 #include "THCDeviceTensorUtils.cuh"
 #include "THCDeviceUtils.cuh"

--- a/lib/THCUNN/SpatialReplicationPadding.cu
+++ b/lib/THCUNN/SpatialReplicationPadding.cu
@@ -1,5 +1,5 @@
 #include "THCUNN.h"
-
+#include "common.h"
 #include "THCDeviceTensor.cuh"
 #include "THCDeviceTensorUtils.cuh"
 #include "THCDeviceUtils.cuh"

--- a/lib/THCUNN/VolumetricReplicationPadding.cu
+++ b/lib/THCUNN/VolumetricReplicationPadding.cu
@@ -1,5 +1,5 @@
 #include "THCUNN.h"
-
+#include "common.h"
 #include "THCDeviceTensor.cuh"
 #include "THCDeviceTensorUtils.cuh"
 #include "THCDeviceUtils.cuh"

--- a/lib/THCUNN/common.h
+++ b/lib/THCUNN/common.h
@@ -22,11 +22,60 @@ inline int GET_BLOCKS(const int N)
 }
 
 #define THCUNN_resizeAs_indices(STATE, I1, I2)              \
-  THLongStorage *size2 = THCTensor_(newSizeOf)(STATE, I2); \
-  if (!THCudaLongTensor_isSize(STATE, I1, size2))           \
+  THLongStorage *size2 = THCTensor_(newSizeOf)(STATE, I2);  \
+  if (!THCIndexTensor_(isSize)(STATE, I1, size2))           \
   { \
     THCudaLongTensor_resize(STATE, I1, size2, NULL);        \
   } \
   THLongStorage_free(size2);
+
+#define THCUNN_check_shape(STATE, I1, I2)                 \
+  if (I1 != NULL && I2 != NULL && !THCTensor_(isSameSizeAs)(STATE, I1, I2))	\
+  { \
+       THCDescBuff s1 = THCTensor_(sizeDesc)(STATE, I1);  \
+       THCDescBuff s2 = THCTensor_(sizeDesc)(STATE, I2);  \
+       THError(#I1 " and " #I2 " shapes do not match: "   \
+               #I1 " %s, " #I2 " %s", s1.str, s2.str);    \
+  }
+
+
+#define THCUNN_check_shape_indices(STATE, I1, I2)              \
+  THLongStorage *size2 = THCTensor_(newSizeOf)(STATE, I2);     \
+  if (!THCIndexTensor_(isSize)(STATE, I1, size2))              \
+  { \
+       THCDescBuff s1 = THCIndexTensor_(sizeDesc)(STATE, I1);  \
+       THCDescBuff s2 = THCTensor_(sizeDesc)(STATE, I2);       \
+       THError(#I1 " and " #I2 " shapes do not match: "        \
+               #I1 " %s, " #I2 " %s", s1.str, s2.str);         \
+  } \
+  THLongStorage_free(size2);
+
+#define THCUNN_check_nElement(STATE, I1, I2)                \
+  if (I1 != NULL && I2 != NULL ) {                          \
+    long n1 = THCTensor_(nElement)(STATE, I1);              \
+    long n2 = THCTensor_(nElement)(STATE, I2);              \
+    if (n1 != n2)                                           \
+    {	\
+      THCDescBuff s1 = THCTensor_(sizeDesc)(state, I1);     \
+      THCDescBuff s2 = THCTensor_(sizeDesc)(state, I2);     \
+      THError(#I1 " and " #I2 " have different number of elements: "	\
+              #I1 "%s has %ld elements, while "             \
+              #I2 "%s has %ld elements", s1.str, n1, s2.str, n2); \
+    }	\
+  }
+
+#define THCUNN_check_dim_size(STATE, T, DIM, DIM_SIZE, SIZE) \
+  if (THCTensor_(nDimension)(STATE, T) != DIM ||             \
+      THCTensor_(size)(STATE, T, DIM_SIZE) != SIZE) {        \
+      THCDescBuff s1 = THCTensor_(sizeDesc)(state, T);       \
+      THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
+              " but got " #T " to be of shape: %s", DIM, DIM_SIZE, SIZE, s1.str); \
+  }
+
+#define THCUNN_argCheck(STATE, COND, ARG, T, FORMAT) \
+  if (!(COND)) { \
+    THCDescBuff s1 = THCTensor_(sizeDesc)(state, T); \
+    THArgCheck(COND, ARG, FORMAT, s1.str);           \
+  }
 
 #endif

--- a/lib/THCUNN/generic/Abs.cu
+++ b/lib/THCUNN/generic/Abs.cu
@@ -20,6 +20,7 @@ void THNN_(Abs_updateGradInput)(
            THCTensor *gradOutput,
            THCTensor *gradInput)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
   THC_pointwiseApply3(state, gradInput, input, gradOutput, absupdateGradInput_functor<real>());

--- a/lib/THCUNN/generic/AbsCriterion.cu
+++ b/lib/THCUNN/generic/AbsCriterion.cu
@@ -9,6 +9,7 @@ void THNN_(AbsCriterion_updateOutput)(
            THCTensor *output,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 2, input, target);
 
   long size = THCTensor_(nElement)(state, input);
@@ -36,6 +37,7 @@ void THNN_(AbsCriterion_updateGradInput)(
            THCTensor *gradInput,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 3, input, target, gradInput);
 
   long size = THCTensor_(nElement)(state, input);

--- a/lib/THCUNN/generic/BCECriterion.cu
+++ b/lib/THCUNN/generic/BCECriterion.cu
@@ -10,6 +10,9 @@ void THNN_(BCECriterion_updateOutput)(
            bool sizeAverage,
            THCTensor *weights)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_nElement(state, input, weights);
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 3, input, target, weights);
 
   long size = THCTensor_(nElement)(state, input);
@@ -59,6 +62,8 @@ void THNN_(BCECriterion_updateGradInput)(
            bool sizeAverage,
            THCTensor *weights)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_nElement(state, input, weights);
   THCUNN_assertSameGPU_generic(state, 4, input, target, gradInput, weights);
 
   long size = THCTensor_(nElement)(state, input);

--- a/lib/THCUNN/generic/BatchNormalization.cu
+++ b/lib/THCUNN/generic/BatchNormalization.cu
@@ -70,6 +70,7 @@ void THNN_(BatchNormalization_backward)(
   THCTensor *weight_, THCTensor *runningMean_, THCTensor *runningVar_,
   THCTensor *saveMean_, THCTensor *saveStd_, bool train, float scale, double eps) {
 
+  THCUNN_check_shape(state, input_, gradOutput_);
   DeviceTensor3 input = devicetensor<3>(state, input_);
   DeviceTensor3 gradOutput = devicetensor<3>(state, gradOutput_);
   DeviceTensor3 gradInput = devicetensor<3>(state, gradInput_);

--- a/lib/THCUNN/generic/ClassNLLCriterion.cu
+++ b/lib/THCUNN/generic/ClassNLLCriterion.cu
@@ -10,6 +10,9 @@ void THNN_(ClassNLLCriterion_updateOutput)(
            bool sizeAverage,
            THCTensor *weights,
            THCTensor *total_weight) {
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
+  THCUNN_check_dim_size(state, total_weight, 1, 0, 1);
+
   if (THCIndexTensor_(nDimension)(state, target) > 1) {
     THError("multi-target not supported");
   }
@@ -31,7 +34,9 @@ void THNN_(ClassNLLCriterion_updateOutput)(
     THArgCheck(0, 2, "vector or matrix expected");
   }
   if (weights && THCTensor_(nElement)(state, weights) != n_classes) {
-    THError("weight tensor should be defined either for all or no classes");
+    THCDescBuff s1 = THCTensor_(sizeDesc)(state, weights);
+    THError("weight tensor should be defined either for all %d classes or no classes"
+            " but got weight tensor of shape: %s", n_classes, s1.str);
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/lib/THCUNN/generic/DistKLDivCriterion.cu
+++ b/lib/THCUNN/generic/DistKLDivCriterion.cu
@@ -9,6 +9,8 @@ void THNN_(DistKLDivCriterion_updateOutput)(
            THCTensor *output,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 2, input, target);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
@@ -41,6 +43,7 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
            THCTensor *gradInput,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 3, input, target, gradInput);
 
   THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,

--- a/lib/THCUNN/generic/ELU.cu
+++ b/lib/THCUNN/generic/ELU.cu
@@ -36,6 +36,7 @@ void THNN_(ELU_updateGradInput)(
            real alpha,
            bool inplace)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, output, gradOutput, gradInput);
 
   if (inplace)

--- a/lib/THCUNN/generic/HardTanh.cu
+++ b/lib/THCUNN/generic/HardTanh.cu
@@ -35,6 +35,7 @@ void THNN_(HardTanh_updateGradInput)(
            real max_val,
            bool inplace)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradOutput, gradInput);
 
   if (inplace)

--- a/lib/THCUNN/generic/L1Cost.cu
+++ b/lib/THCUNN/generic/L1Cost.cu
@@ -7,6 +7,7 @@ void THNN_(L1Cost_updateOutput)(
            THCTensor *input,
            THCTensor *output)
 {
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 1, input);
   accreal sum;
   long size = THCTensor_(nElement)(state, input);
@@ -25,6 +26,7 @@ void THNN_(L1Cost_updateGradInput)(
            THCTensor *gradOutput,
            THCTensor *gradInput)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 2, input, gradInput);
   long size = THCTensor_(nElement)(state, input);
 

--- a/lib/THCUNN/generic/LeakyReLU.cu
+++ b/lib/THCUNN/generic/LeakyReLU.cu
@@ -35,6 +35,7 @@ void THNN_(LeakyReLU_updateGradInput)(
            real negval,
            bool inplace)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradInput, gradOutput);
 
   if (inplace)

--- a/lib/THCUNN/generic/LogSigmoid.cu
+++ b/lib/THCUNN/generic/LogSigmoid.cu
@@ -22,6 +22,7 @@ void THNN_(LogSigmoid_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *buffer)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
   THC_pointwiseApply3(state, gradInput, input, gradOutput, logSigmoid_updateGradInput_functor<real>());

--- a/lib/THCUNN/generic/LogSoftMax.cu
+++ b/lib/THCUNN/generic/LogSoftMax.cu
@@ -113,6 +113,7 @@ void THNN_(LogSoftMax_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *output)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, output, gradOutput, gradInput);
 
   THCTensor_(resizeAs)(state, gradInput, output);

--- a/lib/THCUNN/generic/LookupTable.cu
+++ b/lib/THCUNN/generic/LookupTable.cu
@@ -23,8 +23,10 @@ void THNN_(LookupTable_accGradParameters)(
   }
 
   int nDim = THCIndexTensor_(nDimension)(state, input);
-  if (nDim != 1 && nDim != 2)
-    THError("input must be a vector or matrix");
+  if (THCIndexTensor_(nDimension)(state, input) != 1 && THCIndexTensor_(nDimension)(state, input) != 2) {
+    THCDescBuff s1 = THCIndexTensor_(sizeDesc)(state, input);
+    THError("input must be a vector or matrix, but is of shape: %s", s1.str);
+  }
 
   long numel = THCIndexTensor_(nElement)(state, input);
   long stride = gradWeight->stride[0];

--- a/lib/THCUNN/generic/MSECriterion.cu
+++ b/lib/THCUNN/generic/MSECriterion.cu
@@ -9,10 +9,9 @@ void THNN_(MSECriterion_updateOutput)(
            THCTensor *output,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 2, input, target);
-  THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
-    "input and target need to have the same number of elements"
-  );
 
   long size = THCTensor_(nElement)(state, input);
 
@@ -44,10 +43,8 @@ void THNN_(MSECriterion_updateGradInput)(
            THCTensor *gradInput,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 3, input, target, gradInput);
-  THArgCheck(THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
-    "input and target need to have the same number of elements"
-  );
 
   long size = THCTensor_(nElement)(state, input);
   accreal norm = sizeAverage ? (accreal)(2)/size : (accreal)(2);

--- a/lib/THCUNN/generic/MarginCriterion.cu
+++ b/lib/THCUNN/generic/MarginCriterion.cu
@@ -10,6 +10,8 @@ void THNN_(MarginCriterion_updateOutput)(
            bool sizeAverage,
            real margin)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 2, input, target);
 
   long size = THCTensor_(nElement)(state, input);
@@ -40,6 +42,7 @@ void THNN_(MarginCriterion_updateGradInput)(
            bool sizeAverage,
            real margin)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 3, input, target, gradInput);
 
   long size = THCTensor_(nElement)(state, input);

--- a/lib/THCUNN/generic/MultiMarginCriterion.cu
+++ b/lib/THCUNN/generic/MultiMarginCriterion.cu
@@ -2,6 +2,7 @@
 #define THC_GENERIC_FILE "generic/MultiMarginCriterion.cu"
 #else
 
+// TODO: improve error messages
 void THNN_(MultiMarginCriterion_updateOutput)(
            THCState *state,
            THCTensor *input,
@@ -48,6 +49,9 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   }
   else if (input->nDimension == 2)
   {
+    int nframe = input->size[0];
+    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+               "inconsistent target size");
     THCTensor *output_ = THCTensor_(newWithSize1d)(state, input->size[0]);  // tmp outupt buffer
     dim3 blocks(input->size[0]);
     dim3 threads(MULTIMARGIN_THREADS);
@@ -58,7 +62,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        input->size[0], input->size[1],
+        nframe, input->size[1],
         sizeAverage,
         margin
       );
@@ -139,6 +143,9 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   }
   else if (input->nDimension == 2)
   {
+    int nframe = gradInput->size[0];
+    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+               "inconsistent target size");
     dim3 blocks(gradInput->size[0]);
     dim3 threads(MULTIMARGIN_THREADS);
 
@@ -149,7 +156,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        gradInput->size[0], gradInput->size[1],
+        nframe, gradInput->size[1],
         sizeAverage,
         margin
       );
@@ -161,7 +168,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         THCTensor_(data)(state, input),
         THCIndexTensor_(data)(state, target),
         weights ? THCTensor_(data)(state, weights) : NULL,
-        gradInput->size[0], gradInput->size[1],
+        nframe, gradInput->size[1],
         sizeAverage,
         margin
       );

--- a/lib/THCUNN/generic/PReLU.cu
+++ b/lib/THCUNN/generic/PReLU.cu
@@ -48,6 +48,7 @@ void THNN_(PReLU_updateGradInput)(
            THCTensor *weight,
            long nOutputPlane)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCTensor_(resizeAs)(state, gradInput, input);
 
   real *w = THCTensor_(data)(state, weight);
@@ -93,6 +94,7 @@ void THNN_(PReLU_accGradParameters)(
            long nOutputPlane,
            real scale)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   // use grad input for temporary storage, then call updateGradInput again
 
   if (nOutputPlane == 0)

--- a/lib/THCUNN/generic/RReLU.cu
+++ b/lib/THCUNN/generic/RReLU.cu
@@ -68,6 +68,7 @@ void THNN_(RReLU_updateGradInput)(
            bool train,
            bool inplace)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 4, input, gradOutput, gradInput, noise);
 
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);

--- a/lib/THCUNN/generic/Sigmoid.cu
+++ b/lib/THCUNN/generic/Sigmoid.cu
@@ -21,6 +21,7 @@ void THNN_(Sigmoid_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *output)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
   THC_pointwiseApply3(state, gradInput, output, gradOutput, sigmoidupdateGradInput_functor<real>());

--- a/lib/THCUNN/generic/SmoothL1Criterion.cu
+++ b/lib/THCUNN/generic/SmoothL1Criterion.cu
@@ -9,6 +9,8 @@ void THNN_(SmoothL1Criterion_updateOutput)(
            THCTensor *output,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 2, input, target);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,
@@ -46,6 +48,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
            THCTensor *gradInput,
            bool sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 3, input, target, gradInput);
   THArgCheck(
     THCTensor_(nElement)(state, input) == THCTensor_(nElement)(state, target), 2,

--- a/lib/THCUNN/generic/SoftMarginCriterion.cu
+++ b/lib/THCUNN/generic/SoftMarginCriterion.cu
@@ -9,6 +9,8 @@ void THNN_(SoftMarginCriterion_updateOutput)(
            THCTensor *output,
            int sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
+  THCUNN_check_dim_size(state, output, 1, 0, 1);
   THCUNN_assertSameGPU_generic(state, 2, input, target);
   accreal sum;
 
@@ -37,6 +39,7 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
            THCTensor *gradInput,
            int sizeAverage)
 {
+  THCUNN_check_nElement(state, input, target);
   THCUNN_assertSameGPU_generic(state, 3, input, target, gradInput);
 
   long size = THCTensor_(nElement)(state, input);

--- a/lib/THCUNN/generic/SoftMax.cu
+++ b/lib/THCUNN/generic/SoftMax.cu
@@ -81,6 +81,7 @@ void THNN_(SoftMax_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *output)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, output, gradOutput, gradInput);
 
   output = THCTensor_(newContiguous)(state, output);

--- a/lib/THCUNN/generic/SoftPlus.cu
+++ b/lib/THCUNN/generic/SoftPlus.cu
@@ -25,6 +25,7 @@ void THNN_(SoftPlus_updateGradInput)(
            real beta,
            real threshold)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 4, input, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
   THC_pointwiseApply3(state, gradInput, output, gradOutput, softPlusupdateGradInput_functor<real>(threshold, beta));

--- a/lib/THCUNN/generic/SoftShrink.cu
+++ b/lib/THCUNN/generic/SoftShrink.cu
@@ -23,6 +23,7 @@ void THNN_(SoftShrink_updateGradInput)(
            THCTensor *gradInput,
            real lambda)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
   THC_pointwiseApply3(state, gradInput, input, gradOutput, SoftShrinkUpdateGradInput<real>(lambda));

--- a/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
+++ b/lib/THCUNN/generic/SpatialAdaptiveMaxPooling.cu
@@ -18,7 +18,8 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   real *output_data;
   real *input_data;
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch) tensor expected");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 3) {
     long nInputCols = input->size[2];

--- a/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -12,9 +12,13 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
            THCTensor *total_weight)
 {
   THArgCheck(THCIndexTensor_(nDimension)(state, target) == 3, 1,
-               "only batches of spatial targets supported (3D tensors)");
-  THArgCheck(THCTensor_(nDimension)(state, input) == 4, 2,
-               "only batches of spatial inputs supported (4D tensors)");
+             "only batches of spatial targets supported (3D tensors)" \
+             " but got targets of dimension: %d",                     \
+             THCIndexTensor_(nDimension)(state, target));             \
+  THArgCheck(THCTensor_(nDimension)(state, input) == 4, 2,            \
+             "only batches of spatial inputs supported (4D tensors), "      \
+             "but got input of dimension: %d", THCTensor_(nDimension)(state, input)); \
+
   if (weights && THCTensor_(nElement)(state, weights) != THCTensor_(size)(state, input, 1)) {
     THError("weight tensor should be defined either for all or no classes");
   }
@@ -74,11 +78,11 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
            THCTensor *total_weight)
 {
   THArgCheck(THCIndexTensor_(nDimension)(state, target) == 3, 1,
-               "only batches of spatial targets supported (3D tensors)");
+             "only batches of spatial targets supported (3D tensors)");
   THArgCheck(THCTensor_(nDimension)(state, input) == 4, 2,
-               "only batches of spatial inputs supported (4D tensors)");
+             "only batches of spatial inputs supported (4D tensors)");
   THArgCheck(THCTensor_(isContiguous)(state, gradInput), 4,
-               "gradInput must be contiguous");
+             "gradInput must be contiguous");
   if (weights && THCTensor_(nElement)(state, weights) != THCTensor_(size)(state, input, 1)) {
     THError("weight tensor should be defined either for all or no classes");
   }

--- a/lib/THCUNN/generic/SpatialConvolutionLocal.cu
+++ b/lib/THCUNN/generic/SpatialConvolutionLocal.cu
@@ -19,6 +19,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
   THCUNN_assertSameGPU_generic(state, 5, input, output, weight,
                                  bias, finput);
 
+  // TODO: add argument checking
   long nInputPlane = THCTensor_(size)(state,weight,2)/(kW*kH);
   long nOutputPlane = THCTensor_(size)(state,weight,1);
 

--- a/lib/THCUNN/generic/SpatialDilatedConvolution.cu
+++ b/lib/THCUNN/generic/SpatialDilatedConvolution.cu
@@ -19,12 +19,21 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   if (bias) {
     THCUNN_assertSameGPU_generic(state, 2, weight, bias);
   }
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
-  THArgCheck(weight->nDimension == 4, 4, "weight tensor must be 4D (nOutputPlane,nInputPlane,kH,kW)");
-  THArgCheck(!bias || weight->size[0] == bias->size[0], 4, "nOutputPlane mismatch in weight and bias");
-  THArgCheck(kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
-  THArgCheck(dW > 0 && dH > 0, 10, "stride should be greater than zero");
-  THArgCheck(dilationW > 0 && dilationH > 0, 14, "dilation should be greater than 0");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, weight->nDimension == 4, 4, weight,
+                  "4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+                  "but got: %s");
+  THArgCheck(!bias || weight->size[0] == bias->size[0], 4,
+             "nOutputPlane mismatch in weight and bias");
+  THArgCheck(kW > 0 && kH > 0, 8,
+             "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 10,
+             "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
+  THArgCheck(dilationW > 0 && dilationH > 0, 14,
+             "dilation should be greater than 0, but got dilationH: %d dilationW: %d",
+             dilationH, dilationW);
+
 
   // Params:
   int nInputPlane = weight->size[1];
@@ -32,12 +41,16 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
 
   int batch = 1;
   if (input->nDimension == 3) {
-    THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[0] == nInputPlane, 2,
+               "input channels %d and nInputPlane %d dont match.",
+               input->size[0], nInputPlane);
     // Force batch
     batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
   } else {
-    THArgCheck(input->size[1] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[1] == nInputPlane, 2,
+               "input channels %d and nInputPlane %d dont match",
+               input->size[1], nInputPlane);
   }
 
   long inputWidth   = input->size[3];
@@ -46,8 +59,9 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   long outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   if (outputWidth < 1 || outputHeight < 1)
-    THError("Given input size: (%dx%dx%d). Calculated output size: (%dx%dx%d). Output size is too small",
-        nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
+    THError("Given input size: (%dx%dx%d). "
+            "Calculated output size: (%dx%dx%d). Output size is too small",
+            nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
 
   // Batch size + input planes
   long batchSize = input->size[0];
@@ -165,10 +179,15 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
 
   THCUNN_assertSameGPU_generic(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
-  THArgCheck(weight->nDimension == 4, 4, "weight tensor must be 4D (nOutputPlane,nInputPlane,kH,kW)");
-  THArgCheck(kW > 0 && kH > 0, 9, "kernel size should be greater than zero");
-  THArgCheck(dW > 0 && dH > 0, 11, "stride should be greater than zero");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, weight->nDimension == 4, 4, weight,
+                  "4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+                  "but got: %s");
+  THArgCheck(kW > 0 && kH > 0, 9,
+             "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 11,
+             "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   // Params
   int nInputPlane = weight->size[1];
@@ -270,11 +289,17 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
   if (gradBias) {
    THCUNN_assertSameGPU_generic(state, 2, gradWeight, gradBias);
   }
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
-  THArgCheck(gradWeight->nDimension == 4, 4, "gradWeight tensor must be 4D (nOutputPlane,nInputPlane,kH,kW)");
-  THArgCheck(!gradBias || gradWeight->size[0] == gradBias->size[0], 4, "nOutputPlane mismatch in gradWeight and gradBias");
-  THArgCheck(kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
-  THArgCheck(dW > 0 && dH > 0, 10, "stride should be greater than zero");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, gradWeight->nDimension == 4, 4, gradWeight,
+                  "4D gradWeight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+                  "but got: %s");
+  THArgCheck(!gradBias || gradWeight->size[0] == gradBias->size[0], 4,
+             "nOutputPlane mismatch in gradWeight and gradBias");
+  THArgCheck(kW > 0 && kH > 0, 8,
+             "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 10,
+             "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   // Params
   int nInputPlane = gradWeight->size[1];

--- a/lib/THCUNN/generic/SpatialFractionalMaxPooling.cu
+++ b/lib/THCUNN/generic/SpatialFractionalMaxPooling.cu
@@ -17,8 +17,8 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   long numBatch = 1;
 
   long numInputDims = THCTensor_(nDimension)(state, input);
-  THArgCheck(numInputDims == 3 || numInputDims == 4, 2,
-                "3D or 4D (batch mode) tensor expected");
+  THCUNN_argCheck(state, numInputDims == 3 || numInputDims == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 4) {
     numBatch = THCTensor_(size)(state, input, 0);
@@ -33,9 +33,11 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   long inputW = THCTensor_(size)(state, input, dimw);
 
   THArgCheck(outputH + poolSizeH - 1 < inputH, 6,
-                "poolSizeH too large relative to input height");
+             "poolSizeH (%d) too large relative to input height (%d)",
+             poolSizeH, inputH);
   THArgCheck(outputW + poolSizeW - 1 < inputW, 5,
-                "poolSizeW too large relative to input width");
+             "poolSizeW (%d) too large relative to input width (%d)",
+             poolSizeW, inputW);
 
   THCDeviceTensor<real, 4> devInput;
   THCDeviceTensor<real, 4> devOutput;

--- a/lib/THCUNN/generic/SpatialFullConvolution.cu
+++ b/lib/THCUNN/generic/SpatialFullConvolution.cu
@@ -22,16 +22,21 @@ void THNN_(SpatialFullConvolution_updateOutput)(
   THCUNN_assertSameGPU_generic(state, 6, input, output, weight,
                                  bias, columns, ones);
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   int batch = 1;
   if (input->nDimension == 3) {
-    THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[0] == nInputPlane, 2,
+               "input channels (%d) and nInputPlane (%d) dont match",
+               input->size[0], nInputPlane);
     // Force batch
     batch = 0;
     THCTensor_(resize4d)(state, input, 1, input->size[0], input->size[1], input->size[2]);
   } else {
-    THArgCheck(input->size[1] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[1] == nInputPlane, 2,
+               "input channels (%d) and nInputPlane (%d) dont match",
+               input->size[1], nInputPlane);
   }
 
   long inputWidth   = input->size[3];
@@ -154,9 +159,11 @@ void THNN_(SpatialFullConvolution_updateGradInput)(
   int nInputPlane = THCTensor_(size)(state, weight, 0);
   int nOutputPlane = THCTensor_(size)(state, weight, 1);
 
+  // TODO: check gradOutput shape
   THCUNN_assertSameGPU_generic(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   int batch = 1;
   if (input->nDimension == 3) {
@@ -258,7 +265,8 @@ void THNN_(SpatialFullConvolution_accGradParameters)(
   THCUNN_assertSameGPU_generic(state, 6, input, gradOutput, gradWeight,
                                  gradBias, columns, ones);
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   int batch = 1;
   if (input->nDimension == 3) {

--- a/lib/THCUNN/generic/SpatialMaxUnpooling.cu
+++ b/lib/THCUNN/generic/SpatialMaxUnpooling.cu
@@ -10,7 +10,9 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
            int owidth, int oheight)
 {
   THCUNN_assertSameGPU_generic(state, 3, input, output, indices);
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch) tensor expected");
+  THCUNN_argCheck(state, input->nDimension == 3 || input->nDimension == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_check_shape_indices(state, indices, input);
 
   long nInputCols, nInputRows, nInputPlane, batchSize;
 
@@ -56,21 +58,29 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
            int owidth, int oheight)
 {
   THCUNN_assertSameGPU_generic(state, 4, input, gradOutput, indices, gradInput);
+  THCUNN_check_shape_indices(state, indices, input);
 
   long nInputCols, nInputRows, nInputPlane, batchSize;
+  int dimw = 2;
+  int dimh = 1;
 
   if (input->nDimension == 3) {
-    nInputCols = input->size[2];
-    nInputRows = input->size[1];
     nInputPlane = input->size[0];
     batchSize = 1;
   }
   else
   {
-    nInputCols = input->size[3];
-    nInputRows = input->size[2];
+    ++dimw;
+    ++dimh;
     nInputPlane = input->size[1];
     batchSize = input->size[0];
+  }
+  nInputCols = input->size[dimw];
+  nInputRows = input->size[dimh];
+
+  if(owidth!=gradOutput->size[dimw] || oheight!=gradOutput->size[dimh]){
+     THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d",
+             oheight, owidth,gradOutput->size[dimh],gradOutput->size[dimw]);
   }
 
   input = THCTensor_(newContiguous)(state, input);

--- a/lib/THCUNN/generic/SpatialReplicationPadding.cu
+++ b/lib/THCUNN/generic/SpatialReplicationPadding.cu
@@ -17,8 +17,8 @@ void THNN_(SpatialReplicationPadding_updateOutput)(
   int numBatch = 1;
 
   int numInputDims = THCTensor_(nDimension)(state, input);
-  THArgCheck(numInputDims == 3 || numInputDims == 4, 2,
-             "input must be 3 or 4-dimensional");
+  THCUNN_argCheck(state, numInputDims == 3 || numInputDims == 4, 2, input,
+                  "3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   if (numInputDims == 4) {
     numBatch = THCTensor_(size)(state, input, 0);
@@ -32,6 +32,11 @@ void THNN_(SpatialReplicationPadding_updateOutput)(
   int inputW = THCTensor_(size)(state, input, dimw);
   int outputH = inputH + padT + padB;
   int outputW  = inputW + padL + padR;
+
+  THArgCheck(outputW >= 1 || outputH >= 1 , 2,
+             "input (H: %d, W: %d)is too small."
+             " Calculated output H: %d W: %d",
+             inputH, inputW, outputH, outputW);
 
   THCDeviceTensor<real, 4> devInput;
   THCDeviceTensor<real, 4> devOutput;
@@ -82,6 +87,17 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(
     dimh++;
     dimw++;
   }
+  int iheight = input->size[dimh];
+  int iwidth = input->size[dimw];
+  int oheight = iheight + padT + padB;
+  int owidth  = iwidth + padL + padR;
+
+  THArgCheck(owidth == THCTensor_(size)(state, gradOutput, dimw), 3,
+             "gradOutput width unexpected. Expected: %d, Got: %d",
+             owidth, THCTensor_(size)(state, gradOutput, dimw));
+  THArgCheck(oheight == THCTensor_(size)(state, gradOutput, dimh), 3,
+             "gradOutput height unexpected. Expected: %d, Got: %d",
+             oheight, THCTensor_(size)(state, gradOutput, dimh));
 
   THCTensor_(resizeAs)(state, gradInput, input);
   THCTensor_(zero)(state, gradInput);

--- a/lib/THCUNN/generic/SpatialUpSamplingBilinear.cu
+++ b/lib/THCUNN/generic/SpatialUpSamplingBilinear.cu
@@ -9,6 +9,7 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
            int outputHeight,
            int outputWidth)
 {
+  // TODO: check argument shapes
   input = THCTensor_(newContiguous)(state, input);
   output = THCTensor_(newContiguous)(state, output);
   THCUNN_assertSameGPU_generic(state, 2, input, output);
@@ -45,6 +46,7 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
            int outputHeight,
            int outputWidth)
 {
+  // TODO: check argument shapes
   gradInput = THCTensor_(newContiguous)(state, gradInput);
   gradOutput = THCTensor_(newContiguous)(state, gradOutput);
   THCUNN_assertSameGPU_generic(state, 2, gradOutput, gradInput);

--- a/lib/THCUNN/generic/SpatialUpSamplingNearest.cu
+++ b/lib/THCUNN/generic/SpatialUpSamplingNearest.cu
@@ -10,6 +10,7 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
            THCTensor *output,
            int scale_factor)
 {
+  // TODO: check argument shapes
   THCTensor_(zero)(state, output);
 
   THCUNN_assertSameGPU_generic(state, 2, input, output);
@@ -67,6 +68,7 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
            THCTensor *gradInput,
            int scale_factor)
 {
+  // TODO: check argument shapes
   THCUNN_assertSameGPU_generic(state, 2, gradOutput, gradInput);
 
   THCTensor_(zero)(state, gradInput);

--- a/lib/THCUNN/generic/Sqrt.cu
+++ b/lib/THCUNN/generic/Sqrt.cu
@@ -22,6 +22,7 @@ void THNN_(Sqrt_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *output)
 {
+  THCUNN_check_shape(state, output, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
   THC_pointwiseApply3(state, gradInput, output, gradOutput, sqrtupdateGradInput_functor<real>());

--- a/lib/THCUNN/generic/Square.cu
+++ b/lib/THCUNN/generic/Square.cu
@@ -20,6 +20,7 @@ void THNN_(Square_updateGradInput)(
            THCTensor *gradOutput,
            THCTensor *gradInput)
 {
+  THCUNN_check_shape(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, input);
   THC_pointwiseApply3(state, gradInput, input, gradOutput, squareupdateGradInput_functor<real>());

--- a/lib/THCUNN/generic/Tanh.cu
+++ b/lib/THCUNN/generic/Tanh.cu
@@ -21,6 +21,7 @@ void THNN_(Tanh_updateGradInput)(
            THCTensor *gradInput,
            THCTensor *output)
 {
+  THCUNN_check_shape(state, output, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, output, gradOutput, gradInput);
   THCTensor_(resizeAs)(state, gradInput, output);
   THC_pointwiseApply3(state, gradInput, output, gradOutput, tanhupdateGradInput_functor<real>());

--- a/lib/THCUNN/generic/TemporalConvolution.cu
+++ b/lib/THCUNN/generic/TemporalConvolution.cu
@@ -20,15 +20,20 @@ void THNN_(TemporalConvolution_updateOutput)(
   int dimF = 1; // feature dimension
 
   THCUNN_assertSameGPU_generic(state, 4, input, output, weight, bias);
-  THArgCheck( input->nDimension == 2 || input->nDimension == 3, 2, "2D or 3D(batch mode) tensor expected");
+  THCUNN_argCheck(state, input->nDimension == 2 || input->nDimension == 3, 2, input,
+                  "2D or 3D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 3)
   {
     dimS = 1;
     dimF = 2;
   }
-  THArgCheck( input->size[dimF] == inputFrameSize, 2, "invalid input frame size");
-  THArgCheck( input->size[dimS] >= kW, 2, "input sequence smaller than kernel size");
+  THArgCheck(input->size[dimF] == inputFrameSize, 2,
+             "invalid input frame size. Got: %d, Expected: %d",
+             input->size[dimF], inputFrameSize);
+  THArgCheck(input->size[dimS] >= kW, 2,
+             "input sequence smaller than kernel size. Got: %d, Expected: %d",
+             input->size[dimS], kW);
 
   input = THCTensor_(newContiguous)(state, input);
   outputWindow = THCTensor_(new)(state);

--- a/lib/THCUNN/generic/Threshold.cu
+++ b/lib/THCUNN/generic/Threshold.cu
@@ -41,6 +41,7 @@ void THNN_(Threshold_updateGradInput)(
            real val,
            bool inplace)
 {
+  THCUNN_check_nElement(state, input, gradOutput);
   THCUNN_assertSameGPU_generic(state, 3, input, gradInput, gradOutput);
 
   if (inplace)

--- a/lib/THCUNN/generic/VolumetricConvolution.cu
+++ b/lib/THCUNN/generic/VolumetricConvolution.cu
@@ -17,13 +17,12 @@ void THNN_(VolumetricConvolution_updateOutput)(
   THCTensor *ones = fgradInput;
   THCUNN_assertSameGPU_generic(state, 6, input, output, weight, bias, columns, ones);
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch mode) tensor is expected"
-  );
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
+  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for weight, but got: %s");
 
   int nOutputPlane = (int)weight->size[0];
   int nInputPlane  = (int)weight->size[1];
@@ -158,9 +157,12 @@ void THNN_(VolumetricConvolution_updateGradInput)(
            int dT, int dW, int dH,
            int padT, int padW, int padH)
 {
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
+  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for weight, but got: %s");
+  THCUNN_argCheck(state, gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+                  gradOutput,
+                  "4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
 
   int nOutputPlane = (int)weight->size[0];
   int nInputPlane  = (int)weight->size[1];
@@ -171,9 +173,8 @@ void THNN_(VolumetricConvolution_updateGradInput)(
   THCTensor *gradColumns = finput;
 
   THCUNN_assertSameGPU_generic(state, 5, input, gradOutput, weight, gradColumns, gradInput);
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch mode) tensor is expected"
-  );
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 4)
@@ -276,9 +277,9 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   THCTensor *ones = fgradInput;
   THCUNN_assertSameGPU_generic(state, 6, input, gradOutput, gradWeight, gradBias, columns, ones);
 
-  THArgCheck(gradWeight->nDimension == 5, 4,
-    "5D gradWeight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
+  THCUNN_argCheck(state, gradWeight->nDimension == 5, 4, gradWeight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for gradWeight, but got: %s");
 
   int nOutputPlane = (int)gradWeight->size[0];
   int nInputPlane  = (int)gradWeight->size[1];
@@ -286,10 +287,8 @@ void THNN_(VolumetricConvolution_accGradParameters)(
   int kH           = (int)gradWeight->size[3];
   int kW           = (int)gradWeight->size[4];
 
-  THArgCheck(
-    input->nDimension == 4 || input->nDimension == 5, 2,
-    "3D or 4D (batch mode) tensor is expected"
-  );
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 4)

--- a/lib/THCUNN/generic/VolumetricDilatedConvolution.cu
+++ b/lib/THCUNN/generic/VolumetricDilatedConvolution.cu
@@ -19,8 +19,11 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   if (bias) {
     THCUNN_assertSameGPU_generic(state, 2, weight, bias);
   }
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected, but got: %d", input->nDimension);
-  THArgCheck(weight->nDimension == 5, 4, "weight tensor must be 5D (nOutputPlane,nInputPlane,kT,kH,kW)");
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for weight, but got: %s");
   THArgCheck(!bias || weight->size[0] == bias->size[0], 4, "nOutputPlane mismatch in weight and bias");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 10, "stride should be greater than zero");
@@ -168,9 +171,14 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
 
   THCUNN_assertSameGPU_generic(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(weight->nDimension == 5, 4, "weight tensor must be 5D (nOutputPlane,nInputPlane,kT,kH,kW)");
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+                  gradOutput,
+                  "4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
+  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for weight, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 10, "stride should be greater than zero");
 
@@ -277,9 +285,14 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   if (gradBias) {
    THCUNN_assertSameGPU_generic(state, 2, gradWeight, gradBias);
   }
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(gradWeight->nDimension == 5, 4, "gradWeight tensor must be 5D (nOutputPlane,nInputPlane,kT,kH,kW)");
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+                  "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+                  gradOutput,
+                  "4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
+  THCUNN_argCheck(state, gradWeight->nDimension == 5, 4, gradWeight,
+                  "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+                  "expected for gradWeight, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 10, "stride should be greater than zero");
 

--- a/lib/THCUNN/generic/VolumetricFullConvolution.cu
+++ b/lib/THCUNN/generic/VolumetricFullConvolution.cu
@@ -26,7 +26,12 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
 
   THCUNN_assertSameGPU_generic(state, 6, input, output, weight,
                                  bias, columns, ones);
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+    "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+    "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+    "expected for weight, but got: %s");
+
 
   int batch = 1;
   if (input->nDimension == 4) {
@@ -166,7 +171,11 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
 
   THCUNN_assertSameGPU_generic(state, 5, input, gradOutput, weight,
                                  gradColumns, gradInput);
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+    "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, weight->nDimension == 5, 4, weight,
+    "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+    "expected for weight, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 4) {
@@ -275,7 +284,12 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
 
   THCUNN_assertSameGPU_generic(state, 6, input, gradOutput, gradWeight,
                                  gradBias, columns, ones);
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
+  THCUNN_argCheck(state, input->nDimension == 4 || input->nDimension == 5, 2, input,
+    "4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THCUNN_argCheck(state, gradWeight->nDimension == 5, 4, gradWeight,
+    "5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+    "expected for gradWeight, but got: %s");
+
 
   int batch = 1;
   if (input->nDimension == 4) {

--- a/lib/THCUNN/generic/VolumetricMaxUnpooling.cu
+++ b/lib/THCUNN/generic/VolumetricMaxUnpooling.cu
@@ -39,7 +39,8 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   }
   else
   {
-    THArgCheck(false, 2, "4D or 5D tensor expected");
+    THArgCheck(false, 2, "4D or 5D tensor expected, got %d",
+               THCTensor_(nDimension)(state, input));
   }
 
   if (input->nDimension == 4) /* 4D */
@@ -116,6 +117,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
   int inputHeight;
   int inputWidth;
 
+  // TODO: check gradOutput shape
   THCUNN_assertSameGPU_generic(state, 4, input, indices, gradOutput, gradInput);
 
   if (THCTensor_(nDimension)(state, input) == 4) /* 4D */


### PR DESCRIPTION
Differences from nn equivalent (19d32891f3d1a8a6753cf6a1e8d46f411186230c):
1) No changes to VolumetricConvolutionMM, which doesn't exist in cunn.
2) No changes to HardShrink, which doesn't  exist in cunn.
3) LookupTable doesn't verify that all inputs are within range.