### PR TITLE
Improve fix/shape checks for Temporal and Spatial modules

### DIFF
--- a/lib/THCUNN/generic/SpatialAveragePooling.cu
+++ b/lib/THCUNN/generic/SpatialAveragePooling.cu
@@ -27,11 +27,6 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
 
   THCUNN_argCheck(state, ndim == 3 || ndim == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
-
-  THArgCheck(input->size[dimw] >= kW - padW && input->size[dimh] >= kH - padH, 2,
-             "input image (H: %d, W: %d) smaller than kernel "
-             "size - padding( kH: %d padH: %d kW: %d padW: %d",
-             input->size[dimh], input->size[dimw], kH, padH, kW, padW);
   THArgCheck(kW/2 >= padW && kH/2 >= padH, 2,
              "pad should be smaller than half of kernel size, but got "
              "padW = %d, padH = %d, kW = %d, kH = %d",

--- a/lib/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/lib/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -5,10 +5,10 @@
 #include "../common.h"
 
 static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
-  THCState *state,
-	THCTensor *input, THCTensor *gradOutput, THCIndexTensor *indices,
-	int kH, int kW, int dH, int dW, int padH, int padW,
-	int dilationH, int dilationW, bool ceil_mode) {
+                         THCState *state,
+                         THCTensor *input, THCTensor *gradOutput, THCIndexTensor *indices,
+                         int kH, int kW, int dH, int dW, int padH, int padW,
+                         int dilationH, int dilationW, bool ceil_mode) {
 
   THArgCheck(kW > 0 && kH > 0, 5,
              "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);

--- a/lib/THCUNN/generic/SpatialDilatedMaxPooling.cu
+++ b/lib/THCUNN/generic/SpatialDilatedMaxPooling.cu
@@ -33,11 +33,6 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
 
   THCUNN_argCheck(state, ndim == 3 || ndim == 4, 2, input,
                   "3D or 4D input tensor expected but got: %s");
-
-  THArgCheck(input->size[dimw] >= kW - padW && input->size[dimh] >= kH - padH, 2,
-             "input image (H: %d, W: %d) smaller than kernel "
-             "size - padding( kH: %d padH: %d kW: %d padW: %d",
-             input->size[dimh], input->size[dimw], kH, padH, kW, padW);
   THArgCheck(kW/2 >= padW && kH/2 >= padH, 2,
              "pad should be smaller than half of kernel size, but got "
              "padW = %d, padH = %d, kW = %d, kH = %d",


### PR DESCRIPTION
1. Adds gradOutput shape checks for temporal modules
2. Removes unnecessary (too restrictive and/or redundant) shape checks in Spatial Pooling modules.