### PR TITLE
Fix sliceRange for when nElem < splits

### DIFF
--- a/DataParallelTable.lua
+++ b/DataParallelTable.lua
@@ -463,12 +463,14 @@ function DataParallelTable:apply(callback)
 end
 
 local function sliceRange(nElem, idx, splits)
-   local eltsPerMod = nElem / splits
-   local rangeStart = math.ceil((idx - 1) * eltsPerMod) + 1
-   if idx == splits then
-      return rangeStart, nElem - rangeStart + 1
+   local eltsPerMod = math.floor(nElem / splits)
+   local numExtra = nElem - eltsPerMod * splits
+   if idx <= numExtra then
+     rangeStart = (idx - 1) * (eltsPerMod + 1) + 1
+     return rangeStart, eltsPerMod + 1
    else
-      return rangeStart, math.ceil(idx * eltsPerMod) - rangeStart + 1
+     rangeStart = numExtra * (eltsPerMod + 1) + (idx - 1 - numExtra) * eltsPerMod + 1
+     return rangeStart, eltsPerMod
    end
 end
 


### PR DESCRIPTION
Thanks to @ngimel for the fix. We discovered this bug while testing DIGITS with 4+ GPUs.

Test with:
```lua
for gpus=1,8 do
   for batch=1,gpus*2 do
      sum = 0
      for idx=1,gpus do
         start, elts = sliceRange(batch, idx, gpus)
         sum = sum + elts
         if elts == 0 then
             break
         end
      end
      if sum ~= batch then
          print('ERROR when gpus=' .. gpus .. ' and batch=' .. batch)
      end
   end
end
```
The old function failed for several gpu/batch combinations:
```
ERROR when gpus=4 and batch=2	
ERROR when gpus=5 and batch=2	
ERROR when gpus=5 and batch=3	
ERROR when gpus=6 and batch=2	
ERROR when gpus=6 and batch=3	
ERROR when gpus=6 and batch=4	
ERROR when gpus=7 and batch=2	
ERROR when gpus=7 and batch=3	
ERROR when gpus=7 and batch=4	
ERROR when gpus=7 and batch=5	
ERROR when gpus=8 and batch=2	
ERROR when gpus=8 and batch=3	
ERROR when gpus=8 and batch=4	
ERROR when gpus=8 and batch=5	
ERROR when gpus=8 and batch=6
```
I would add this to the testsuite, but `sliceRange` is a local function and I'm not sure the best way to expose it to the test suite.