### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
+cunn = nil
+
 require "cutorch"
 require "nn"
 require "cunn.THCUNN"


### PR DESCRIPTION
In order to use cunn in terra we must not have 'undeclared' variables.
It turns out the cunn table is initialized by: 
```
cunn = cunn or {}
```
... in test.lua, which terra views as an undeclared use.