### PR TITLE
Add missing free in LookupTable

### DIFF
--- a/lib/THCUNN/generic/LookupTable.cu
+++ b/lib/THCUNN/generic/LookupTable.cu
@@ -42,6 +42,7 @@ void THNN_(LookupTable_accGradParameters)(
       numel,
       stride,
       paddingValue);
+    THCTensor_(free)(state, gradOutput);
     THCudaCheck(cudaGetLastError());
     return;
   }


### PR DESCRIPTION
There are two exit points in `accGradParameters` and one of them is missing a `free` on gradOutput (`newContiguous` is called on it [at the beginning](https://github.com/torch/cunn/compare/master...apaszke:lookup_leak?expand=1#diff-5d6c9b1c7b1eb8b369bb74867cb73867R18)).