### PR TITLE
Add THCUNN_generic_h.lua to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 THCUNN_h.lua
+THCUNN_generic_h.lua


### PR DESCRIPTION
Since THCUNN was made generic, this file is now generated by the build, so it makes sense to .gitignore it.