### PR TITLE
Do SpatialClassNLLCriterion sizeAverage in a separate kernel

### DIFF
--- a/lib/THCUNN/SpatialClassNLLCriterion.cu
+++ b/lib/THCUNN/SpatialClassNLLCriterion.cu
@@ -48,11 +48,17 @@ __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
 
   if (threadIdx.x == 0) {
     atomicAdd(total_weight, ScalarConvert<AccumT, T>::to(acc_weight));
-    if (size_average && acc_weight > 0)
-      atomicAdd(output, ScalarConvert<AccumT, T>::to(input_sum / acc_weight / gridDim.x));
-    else
-      atomicAdd(output, ScalarConvert<AccumT, T>::to(input_sum));
+    atomicAdd(output, ScalarConvert<AccumT, T>::to(input_sum));
   }
+}
+
+template<typename T>
+__global__ void cunn_SpatialClassNLLCriterion_sizeAverage_kernel(
+          T *output,
+          T *total_weight)
+{
+  if (*total_weight > 0)
+    *output = THCNumerics<T>::div(*output, *total_weight);
 }
 
 template<typename T>

--- a/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/lib/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -78,6 +78,12 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
       blocks_per_sample
   );
   THCudaCheck(cudaGetLastError());
+  if (sizeAverage) {
+    cunn_SpatialClassNLLCriterion_sizeAverage_kernel<<<1, 1, 0, THCState_getCurrentStream(state)>>>(
+      output_data, total_weight_data
+    );
+    THCudaCheck(cudaGetLastError());
+  }
 
   if (weights)
     THCTensor_(free)(state, weights);


### PR DESCRIPTION
Apparently in SpatialClassNLLCriterion there are so many atomicAdds, that most of the later ones suffer from serious underflows, and that results in differences between CPU and CUDA implementations as large as 5e-3. Moving the averaging to a separate kernel pushes them down to around 1e-8. I think we can afford an additional kernel launch for the sake of correctness.