### PR TITLE
Remove accreal typedef because it is defined multiple times

### DIFF
--- a/THCUNN.lua
+++ b/THCUNN.lua
@@ -45,22 +45,15 @@ local replacements_generic =
     ['THCTensor'] = 'THCudaTensor',
     ['THCIndexTensor'] = 'THCudaLongTensor',
     ['TYPE'] = 'Cuda',
-    ['real'] = 'float',
+    ['accreal'] = 'float',
   },
   {
     ['THCTensor'] = 'THCudaDoubleTensor',
     ['THCIndexTensor'] = 'THCudaLongTensor',
     ['TYPE'] = 'CudaDouble',
-    ['real'] = 'double',
+    ['accreal'] = 'double',
    }
 }
-
--- gsub(s, 'real', 'float') changes accreal to accfloat.
--- typedef accfloat ahead of time.
-ffi.cdef("typedef float accfloat;")
--- gsub(s, 'real', 'double') changes accreal to accfloat.
--- typedef accdouble ahead of time
-ffi.cdef("typedef double accdouble;")
 
 if cutorch.hasHalf then
   ffi.cdef("half THC_float2half(float a);")
@@ -70,12 +63,9 @@ if cutorch.hasHalf then
     ['THCTensor'] = 'THCudaHalfTensor',
     ['THCIndexTensor'] = 'THCudaLongTensor',
     ['TYPE'] = 'CudaHalf',
-    ['real'] = 'half',
+    ['accreal'] = 'float',
   }
   table.insert(replacements_generic, half_replacement)
-  -- gsub(s, 'real', 'double') changes accreal to accfloat.
-  -- typedef acchalf ahead of time
-  ffi.cdef("typedef float acchalf;")
 end
 
 for i=1,#replacements_generic do


### PR DESCRIPTION
with nn.

Both THNN and THCUNN define the accfloat/accdouble typedef via ffi.  The behavior of this seems to be lua version/luajit version dependent (saw test failures with luajit) and it's probably a good idea to get rid of it (as C doesn't let you redefine a typedef in any case).

Since we no longer support 'real' in the header declaration, it makes sense to just define the gsub on accreal; if we want to add back real support we'll have to do something more complicated.