### PR TITLE
Fix inconsistent in-place and out-of-place for HardTanh

### DIFF
--- a/lib/THCUNN/HardTanh.cu
+++ b/lib/THCUNN/HardTanh.cu
@@ -46,7 +46,7 @@ struct hardtanhupdateGradInput_functor
 
   __device__ void operator()(T *gradInput, const T *input, const T *gradOutput) const
   {
-    if (*input < min_val_ || *input > max_val_)
+    if (*input <= min_val_ || *input >= max_val_)
       *gradInput = ScalarConvert<int, T>::to(0);
     else
       *gradInput = *gradOutput;


### PR DESCRIPTION
in-place and out-of-place updateGradOutput results are different where input=min_val or input=max_val